### PR TITLE
feat: Implement server-side initial admin user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The SSO server application is located in the `apps/ssso` directory.
     go run . # Assuming main.go or ssso.go is in apps/ssso
     ```
 
+<<<<<<< HEAD
 ### 🐳 Running with Docker (Standard SSSO)
 
 A `Dockerfile` is provided at the root of the project for the standard SSSO server.
@@ -155,6 +156,47 @@ The easiest way to run the `ssso-alt` variant along with its `ssso-dts` dependen
     *   Standard SSSO environment variables like `SSSO_MONGO_URI`, `SSSO_ISSUER_URL`, etc., are still required as `ssso-alt` uses MongoDB for non-DTS data.
 
     Refer to `apps/ssso-alt/config/config.go` and the `docker-compose.yml` for all configurable options.
+=======
+### 🚀 Initial Admin User Setup
+
+On its first startup, the Shadow SSO server can automatically create an initial administrator user if no other admin users exist in the database. This is useful for bootstrapping a new deployment.
+
+**Configuration:**
+
+This feature is primarily configured via Helm when deploying to Kubernetes, or by setting specific environment variables if running the server binary directly.
+
+**Helm Chart Configuration (`values.yaml`):**
+
+Under the `initialAdmin` section in your `values.yaml` file:
+
+*   `enabled`: (boolean, e.g., `true`) Set to `true` to enable this feature. If `false`, the server will not attempt to create an initial admin.
+*   `createSecret`: (boolean, e.g., `true`) If `true`, Helm will create a Kubernetes Secret to store the initial admin credentials. If `false`, you must ensure a secret named by `secretName` already exists with the required data.
+*   `secretName`: (string, e.g., `ssso-initial-admin-credentials`) The name of the Kubernetes Secret that holds (or will hold) the initial admin credentials.
+*   `credentials`: A map containing:
+    *   `email`: (string) The email address for the initial admin user.
+    *   `password`: (string) The password for the initial admin user. **This must be changed from the default for any real deployment.**
+    *   `firstName`: (string, optional) The first name for the admin user. Defaults to "Admin" if not provided or key is missing in secret.
+    *   `lastName`: (string, optional) The last name for the admin user. Defaults to "User" if not provided or key is missing in secret.
+
+**Environment Variables:**
+
+The server application reads the following environment variables (which are typically populated from the Kubernetes Secret by the Helm chart):
+
+*   `INITIAL_ADMIN_ENABLED`: Set to `"true"` to enable the feature.
+*   `INITIAL_ADMIN_EMAIL`: Email for the first admin.
+*   `INITIAL_ADMIN_PASSWORD`: Password for the first admin.
+*   `INITIAL_ADMIN_FIRST_NAME`: (Optional) First name.
+*   `INITIAL_ADMIN_LAST_NAME`: (Optional) Last name.
+
+**Behavior:**
+
+*   On startup, if `INITIAL_ADMIN_ENABLED` is `"true"`, the server checks if any users with the "admin" role exist.
+*   If no admin users are found, it attempts to read the other `INITIAL_ADMIN_*` environment variables and create the user.
+*   If an admin user already exists, or if the feature is not enabled, this setup step is skipped.
+*   The server will log its actions regarding this setup process.
+
+This ensures that your SSO system can be initialized with a primary administrator account without manual database intervention on the first run.
+>>>>>>> 46dc357 (feat: Implement server-side initial admin user creation)
 
 ###  CLI Tool (`ssoctl`)
 

--- a/README_FRONTEND.md
+++ b/README_FRONTEND.md
@@ -42,6 +42,31 @@ In this flow, when a Relying Party (RP) initiates an OIDC login, if the user is 
     *   Display your login form (username/password).
     *   Handle any multi-factor authentication (2FA/MFA) steps if required by your policies. This guide primarily focuses on the initial credential submission. Advanced 2FA flows might involve additional API calls not detailed here.
 
+    ### Logging in with Social Providers (e.g., Google, Facebook, GitHub)
+
+    As an alternative or addition to the traditional email/password login, your frontend can offer users the option to log in using their existing accounts with social identity providers.
+
+    **User Experience:**
+
+    1.  On your login page, alongside the email/password form, display buttons such as "Login with Google", "Login with Facebook", or "Login with GitHub".
+    2.  When the user clicks one of these buttons, your frontend application should redirect the user's browser to a specific endpoint on the Shadow SSO backend that initiates the chosen social login. This endpoint will typically include the `flowId` and the identifier of the chosen social provider.
+        *   Example initiation URL (actual URL pattern to be confirmed with backend team):
+            `https://your-sso-backend.com/api/oidc/federate/{provider}?flowId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+            (Where `{provider}` could be `google`, `facebook`, `github`, etc.)
+    3.  The Shadow SSO backend will then redirect the user to the respective social provider's authentication page (e.g., Google's login page).
+    4.  The user authenticates with the social provider (e.g., enters Google credentials).
+    5.  Upon successful authentication with the social provider, the user is redirected back to a callback endpoint on the Shadow SSO backend.
+    6.  The Shadow SSO backend processes the social provider's response, links or creates a local user account, establishes an OP session, generates an authorization code, and finally redirects the user back to the Relying Party's `redirect_uri` (similar to the success case in step 5 of the email/password flow).
+
+    **Administrator/Developer Notes:**
+
+    *   **Backend Configuration Required:** For social login buttons to function, the Shadow SSO backend must be pre-configured by an administrator for each social provider. This involves:
+        *   Registering an OAuth application with the social provider (e.g., Google Cloud Console, Facebook for Developers, GitHub OAuth Apps).
+        *   Obtaining a Client ID and Client Secret from the social provider.
+        *   Configuring these credentials and other provider-specific details (like scopes) as an Identity Provider (IdP) within the Shadow SSO backend system.
+    *   **Frontend Responsibility:** The primary responsibility of the frontend is to provide the UI elements (buttons) and correctly redirect the user to the appropriate social login initiation endpoint on the Shadow SSO backend, passing along the current `flowId`. The rest of the social login dance (communication with the social provider, token exchange, user linking/creation) is handled by the Shadow SSO backend.
+    *   **Error Handling:** If a social login attempt fails (e.g., user cancels, provider error, misconfiguration), the Shadow SSO backend should ideally redirect back to your frontend UI with appropriate error information in the URL query parameters, allowing your frontend to display a message to the user. The exact error reporting mechanism should be coordinated with the backend team.
+
 4.  **Frontend Submits Authentication Data to OIDC Provider:**
     *   Once the user successfully authenticates on your frontend (e.g., enters correct username/password), make a `POST` request to the Shadow SSO backend:
         *   **Endpoint:** `POST /api/oidc/authenticate`

--- a/domain/mocks/mock_repositories.go
+++ b/domain/mocks/mock_repositories.go
@@ -219,6 +219,36 @@ func (m *MockUserRepository) EXPECT() *MockUserRepositoryMockRecorder {
 	return m.recorder
 }
 
+// CountUsers mocks base method.
+func (m *MockUserRepository) CountUsers(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountUsers", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountUsers indicates an expected call of CountUsers.
+func (mr *MockUserRepositoryMockRecorder) CountUsers(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUsers", reflect.TypeOf((*MockUserRepository)(nil).CountUsers), ctx)
+}
+
+// CountUsersByRole mocks base method.
+func (m *MockUserRepository) CountUsersByRole(ctx context.Context, role string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountUsersByRole", ctx, role)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountUsersByRole indicates an expected call of CountUsersByRole.
+func (mr *MockUserRepositoryMockRecorder) CountUsersByRole(ctx, role any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUsersByRole", reflect.TypeOf((*MockUserRepository)(nil).CountUsersByRole), ctx, role)
+}
+
 // CreateUser mocks base method.
 func (m *MockUserRepository) CreateUser(ctx context.Context, user *domain.User) error {
 	m.ctrl.T.Helper()

--- a/domain/repositories.go
+++ b/domain/repositories.go
@@ -35,6 +35,8 @@ type UserRepository interface {
 	UpdateUser(ctx context.Context, user *User) error                                       // Could also be UpdateUser(id, updates map[string]interface{})
 	DeleteUser(ctx context.Context, id string) error                                        // Optional, consider soft delete by status
 	ListUsers(ctx context.Context, pageToken string, pageSize int) ([]*User, string, error) // Returns users, next page token, error
+	CountUsers(ctx context.Context) (int64, error)                                         // Method to count all users
+	CountUsersByRole(ctx context.Context, role string) (int64, error)                      // New method to count users by role
 }
 
 // SessionRepository defines methods for user session persistence.

--- a/domain/user.go
+++ b/domain/user.go
@@ -1,6 +1,12 @@
 package domain
 
-import "time"
+import (
+	"errors" // Added for ErrUserNotFound
+	"time"
+)
+
+// ErrUserNotFound is returned when a user is not found in the repository.
+var ErrUserNotFound = errors.New("user not found")
 
 // UserStatus defines the possible statuses of a user account.
 type UserStatus string

--- a/helm/ssso-backend/templates/deployment.yaml
+++ b/helm/ssso-backend/templates/deployment.yaml
@@ -50,6 +50,32 @@ spec:
               value: {{ include "ssso-backend.mongodb.uri" . | quote }}
             - name: SSSO_MONGO_DB_NAME
               value: {{ include "ssso-backend.mongodb.databaseName" . | quote }}
+            {{- if .Values.initialAdmin.enabled }}
+            - name: INITIAL_ADMIN_ENABLED
+              value: "true"
+            - name: INITIAL_ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.initialAdmin.secretName }}
+                  key: INITIAL_ADMIN_EMAIL
+            - name: INITIAL_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.initialAdmin.secretName }}
+                  key: INITIAL_ADMIN_PASSWORD
+            - name: INITIAL_ADMIN_FIRST_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.initialAdmin.secretName }}
+                  key: INITIAL_ADMIN_FIRST_NAME
+                  optional: true # Server provides default if key is missing in secret
+            - name: INITIAL_ADMIN_LAST_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.initialAdmin.secretName }}
+                  key: INITIAL_ADMIN_LAST_NAME
+                  optional: true # Server provides default if key is missing in secret
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/ssso-backend/templates/secrets.yaml
+++ b/helm/ssso-backend/templates/secrets.yaml
@@ -8,6 +8,24 @@ metadata:
 type: Opaque
 data:
   private.pem: {{ .Values.signingKeyPrivatePem | b64enc }}
+---
+{{- end }}
+{{- if .Values.initialAdmin.enabled }}
+{{- if .Values.initialAdmin.createSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.initialAdmin.secretName }}
+  labels:
+    {{- include "ssso-backend.labels" . | nindent 4 }}
+type: Opaque
+data:
+  INITIAL_ADMIN_EMAIL: {{ .Values.initialAdmin.credentials.email | b64enc }}
+  INITIAL_ADMIN_PASSWORD: {{ .Values.initialAdmin.credentials.password | b64enc }}
+  INITIAL_ADMIN_FIRST_NAME: {{ .Values.initialAdmin.credentials.firstName | b64enc }}
+  INITIAL_ADMIN_LAST_NAME: {{ .Values.initialAdmin.credentials.lastName | b64enc }}
+---
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/ssso-backend/values.yaml
+++ b/helm/ssso-backend/values.yaml
@@ -4,6 +4,21 @@
 
 replicaCount: 1
 
+initialAdmin:
+  # enabled controls whether the server will attempt to create an initial admin user on startup.
+  # This requires INITIAL_ADMIN_EMAIL and INITIAL_ADMIN_PASSWORD to be set (e.g., via the secret).
+  enabled: true
+  # createSecret controls whether Helm should create the K8s Secret for these credentials.
+  # If false, initialAdmin.secretName must point to a pre-existing Secret.
+  createSecret: true
+  secretName: "ssso-initial-admin-credentials"
+  credentials:
+    email: "admin@example.com"
+    # !!IMPORTANT!!: This default password MUST be changed in a values override file for any real deployment.
+    password: "changemeStrongPassword123!"
+    firstName: "Admin" # Optional, defaults in server if not provided
+    lastName: "User"   # Optional, defaults in server if not provided
+
 image:
   repository: ghcr.io/pilab-dev/shadow-sso-backend
   pullPolicy: IfNotPresent


### PR DESCRIPTION
- Added logic to the SSSO server startup sequence to create an initial admin user if no admin users exist in the database.
- This feature is controlled by environment variables, which are sourced from a Kubernetes Secret managed by Helm.
- Updated UserRepository to include `CountUsersByRole` for checking admin existence.
- Standardized `ErrUserNotFound` in the domain layer.
- Updated Helm chart (values.yaml, secrets.yaml, deployment.yaml) to configure this feature, manage the initial admin credentials secret, and pass necessary environment variables to the application.
- This approach replaces the previous init-container based strategy.

docs: Update READMEs with initial admin setup and social login info

- Updated README.md to include a section detailing the server-side initial admin user setup feature, its configuration via Helm and environment variables, and its behavior.
- Updated README_FRONTEND.md to include a section on logging in with social providers, outlining the user flow and backend configuration prerequisites for this feature.