### PR TITLE
feat(oidc): implement /oauth2/userinfo endpoint

### DIFF
--- a/api/openidv2_1/handlers.go
+++ b/api/openidv2_1/handlers.go
@@ -109,6 +109,7 @@ func (oa *OAuth2API) RegisterRoutes(e *gin.Engine) {
 	e.GET("/oauth2/authorize", oa.AuthorizeHandler)
 	e.POST("/oauth2/device_authorization", oa.DeviceAuthorizationHandler)
 	e.GET("/oauth2/userinfo", oa.UserInfoHandler)
+	e.POST("/oauth2/userinfo", oa.UserInfoHandler)
 	e.POST("/oauth2/revoke", oa.RevokeHandler)
 	e.POST("/oauth2/introspect", oa.IntrospectHandler)
 
@@ -895,30 +896,67 @@ func (oa *OAuth2API) UserInfoHandler(c *gin.Context) {
 		return
 	}
 
-	// ctx := c.Request.Context() // Removed unused ctx
-
-	// Get bearer token
 	tokenParts := strings.Split(authHeader, " ")
 	if len(tokenParts) != 2 || tokenParts[0] != "Bearer" {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token"})
 		return
 	}
-	// token := tokenParts[1] // Removed unused token
 
-	// Validate token, and get user info
-	// TODO: Implement UserInfo endpoint correctly.
-	// This should involve validating the token and then fetching claims.
-	// The OAuthService.GetUserInfo method was removed as it was a stub.
-	// This functionality likely belongs in AuthService or a dedicated UserInfoService.
-	// For now, returning a placeholder or an error.
-	// userInfo, err := oa.service.GetUserInfo(ctx, token)
-	// if err != nil {
-	// 	c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token"})
-	// 	return
-	// }
-	// c.JSON(http.StatusOK, userInfo)
-	log.Error().Msg("UserInfoHandler: GetUserInfo not implemented")
-	c.JSON(http.StatusNotImplemented, gin.H{"error": "not_implemented", "error_description": "Userinfo endpoint is not yet fully implemented."})
+	token := tokenParts[1]
+	ctx := c.Request.Context()
+
+	tokenInfo, err := oa.tokenService.ValidateAccessToken(ctx, token)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token"})
+		return
+	}
+
+	var userInfo sssoapi.UserInfo
+	if tokenInfo.TokenType == "service_account_jwt" {
+		userInfo = sssoapi.UserInfo{
+			Sub: tokenInfo.UserID,
+		}
+	} else {
+		user, err := oa.userRepo.GetUserByID(ctx, tokenInfo.UserID)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token"})
+			return
+		}
+
+		if user.Status != domain.UserStatusActive {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_token"})
+			return
+		}
+
+		var name, givenName, familyName *string
+		fullName := strings.TrimSpace(user.FirstName + " " + user.LastName)
+		if fullName != "" {
+			name = &fullName
+		}
+		if user.FirstName != "" {
+			givenName = &user.FirstName
+		}
+		if user.LastName != "" {
+			familyName = &user.LastName
+		}
+
+		email := user.Email
+		preferredUsername := user.Email
+		emailVerified := user.Status == domain.UserStatusActive
+
+		userInfo = sssoapi.UserInfo{
+			Sub:               user.ID,
+			Name:              name,
+			GivenName:         givenName,
+			FamilyName:        familyName,
+			PreferredUsername: &preferredUsername,
+			Email:             &email,
+			EmailVerified:     &emailVerified,
+		}
+	}
+
+	c.Header("Cache-Control", "no-store")
+	c.JSON(http.StatusOK, userInfo)
 }
 
 // RevokeHandler handles token revocation requests according to RFC 7009.

--- a/api/openidv2_1/handlers.go
+++ b/api/openidv2_1/handlers.go
@@ -942,7 +942,7 @@ func (oa *OAuth2API) UserInfoHandler(c *gin.Context) {
 
 		email := user.Email
 		preferredUsername := user.Email
-		emailVerified := user.Status == domain.UserStatusActive
+		emailVerified := user.IsEmailVerified
 
 		userInfo = sssoapi.UserInfo{
 			Sub:               user.ID,

--- a/api/openidv2_1/handlers_test.go
+++ b/api/openidv2_1/handlers_test.go
@@ -970,11 +970,12 @@ func TestUserInfoHandler_Success_GET(t *testing.T) {
 		TokenType: "access_token",
 	}, nil)
 	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user1").Return(&domain.User{
-		ID:        "user1",
-		Email:     email,
-		FirstName: firstName,
-		LastName:  lastName,
-		Status:    domain.UserStatusActive,
+		ID:             "user1",
+		Email:          email,
+		FirstName:      firstName,
+		LastName:       lastName,
+		Status:         domain.UserStatusActive,
+		IsEmailVerified: true,
 	}, nil)
 
 	req := httptest.NewRequest("GET", "/oauth2/userinfo", nil)
@@ -1016,11 +1017,12 @@ func TestUserInfoHandler_Success_POST(t *testing.T) {
 		TokenType: "access_token",
 	}, nil)
 	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user1").Return(&domain.User{
-		ID:        "user1",
-		Email:     email,
-		FirstName: firstName,
-		LastName:  lastName,
-		Status:    domain.UserStatusActive,
+		ID:             "user1",
+		Email:          email,
+		FirstName:      firstName,
+		LastName:       lastName,
+		Status:         domain.UserStatusActive,
+		IsEmailVerified: true,
 	}, nil)
 
 	req := httptest.NewRequest("POST", "/oauth2/userinfo", nil)

--- a/api/openidv2_1/handlers_test.go
+++ b/api/openidv2_1/handlers_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pilab-dev/shadow-sso/internal/oidcflow"
 	pkgauth "github.com/pilab-dev/shadow-sso/pkg/auth"
 	"github.com/pilab-dev/shadow-sso/services"
+	services_mocks "github.com/pilab-dev/shadow-sso/services/mocks"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -935,3 +936,260 @@ func CalculateS256Challenge(verifier string) string {
 }
 
 // [end of api/gin/handlers_test.go]
+
+func setupUserInfoTest(t *testing.T) (*gin.Engine, *gomock.Controller, *services_mocks.MockTokenService, *mock_domain.MockUserRepository) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	mockTokenSvc := services_mocks.NewMockTokenService(ctrl)
+	mockUserRepo := mock_domain.NewMockUserRepository(ctrl)
+
+	api := sssogin.NewOAuth2API(&sssogin.OAuth2APIOptions{
+		TokenService: mockTokenSvc,
+		UserRepo:     mockUserRepo,
+		Config: &sssoapi.OpenIDProviderConfig{
+			NextJSLoginURL: "http://localhost:3000/login",
+		},
+	})
+
+	router := gin.New()
+	api.RegisterRoutes(router)
+	return router, ctrl, mockTokenSvc, mockUserRepo
+}
+
+func TestUserInfoHandler_Success_GET(t *testing.T) {
+	router, ctrl, mockTokenSvc, mockUserRepo := setupUserInfoTest(t)
+	defer ctrl.Finish()
+
+	firstName := "Test"
+	lastName := "User"
+	email := "test@test.com"
+
+	mockTokenSvc.EXPECT().ValidateAccessToken(gomock.Any(), "valid-token").Return(&domain.Token{
+		UserID:    "user1",
+		TokenType: "access_token",
+	}, nil)
+	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user1").Return(&domain.User{
+		ID:        "user1",
+		Email:     email,
+		FirstName: firstName,
+		LastName:  lastName,
+		Status:    domain.UserStatusActive,
+	}, nil)
+
+	req := httptest.NewRequest("GET", "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+
+	var resp sssoapi.UserInfo
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "user1", resp.Sub)
+	require.NotNil(t, resp.Email)
+	assert.Equal(t, "test@test.com", *resp.Email)
+	require.NotNil(t, resp.Name)
+	assert.Equal(t, "Test User", *resp.Name)
+	require.NotNil(t, resp.GivenName)
+	assert.Equal(t, "Test", *resp.GivenName)
+	require.NotNil(t, resp.FamilyName)
+	assert.Equal(t, "User", *resp.FamilyName)
+	require.NotNil(t, resp.PreferredUsername)
+	assert.Equal(t, "test@test.com", *resp.PreferredUsername)
+	require.NotNil(t, resp.EmailVerified)
+	assert.True(t, *resp.EmailVerified)
+}
+
+func TestUserInfoHandler_Success_POST(t *testing.T) {
+	router, ctrl, mockTokenSvc, mockUserRepo := setupUserInfoTest(t)
+	defer ctrl.Finish()
+
+	firstName := "Test"
+	lastName := "User"
+	email := "test@test.com"
+
+	mockTokenSvc.EXPECT().ValidateAccessToken(gomock.Any(), "valid-token").Return(&domain.Token{
+		UserID:    "user1",
+		TokenType: "access_token",
+	}, nil)
+	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user1").Return(&domain.User{
+		ID:        "user1",
+		Email:     email,
+		FirstName: firstName,
+		LastName:  lastName,
+		Status:    domain.UserStatusActive,
+	}, nil)
+
+	req := httptest.NewRequest("POST", "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+
+	var resp sssoapi.UserInfo
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "user1", resp.Sub)
+	require.NotNil(t, resp.Email)
+	assert.Equal(t, "test@test.com", *resp.Email)
+	require.NotNil(t, resp.Name)
+	assert.Equal(t, "Test User", *resp.Name)
+}
+
+func TestUserInfoHandler_MissingToken(t *testing.T) {
+	router, ctrl, _, _ := setupUserInfoTest(t)
+	defer ctrl.Finish()
+
+	req := httptest.NewRequest("GET", "/oauth2/userinfo", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "missing_token", resp["error"])
+}
+
+func TestUserInfoHandler_InvalidAuthFormat(t *testing.T) {
+	router, ctrl, _, _ := setupUserInfoTest(t)
+	defer ctrl.Finish()
+
+	req := httptest.NewRequest("GET", "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "NotBearer token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "invalid_token", resp["error"])
+}
+
+func TestUserInfoHandler_InvalidToken(t *testing.T) {
+	router, ctrl, mockTokenSvc, _ := setupUserInfoTest(t)
+	defer ctrl.Finish()
+
+	mockTokenSvc.EXPECT().ValidateAccessToken(gomock.Any(), "bad-token").Return(nil, errors.New("invalid"))
+
+	req := httptest.NewRequest("GET", "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer bad-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "invalid_token", resp["error"])
+}
+
+func TestUserInfoHandler_UserNotFound(t *testing.T) {
+	router, ctrl, mockTokenSvc, mockUserRepo := setupUserInfoTest(t)
+	defer ctrl.Finish()
+
+	mockTokenSvc.EXPECT().ValidateAccessToken(gomock.Any(), "valid-token").Return(&domain.Token{
+		UserID:    "user1",
+		TokenType: "access_token",
+	}, nil)
+	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user1").Return(nil, errors.New("not found"))
+
+	req := httptest.NewRequest("GET", "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "invalid_token", resp["error"])
+}
+
+func TestUserInfoHandler_LockedUser(t *testing.T) {
+	router, ctrl, mockTokenSvc, mockUserRepo := setupUserInfoTest(t)
+	defer ctrl.Finish()
+
+	mockTokenSvc.EXPECT().ValidateAccessToken(gomock.Any(), "valid-token").Return(&domain.Token{
+		UserID:    "user1",
+		TokenType: "access_token",
+	}, nil)
+	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user1").Return(&domain.User{
+		ID:     "user1",
+		Email:  "locked@test.com",
+		Status: domain.UserStatusLocked,
+	}, nil)
+
+	req := httptest.NewRequest("GET", "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "invalid_token", resp["error"])
+}
+
+func TestUserInfoHandler_PendingUser(t *testing.T) {
+	router, ctrl, mockTokenSvc, mockUserRepo := setupUserInfoTest(t)
+	defer ctrl.Finish()
+
+	mockTokenSvc.EXPECT().ValidateAccessToken(gomock.Any(), "valid-token").Return(&domain.Token{
+		UserID:    "user1",
+		TokenType: "access_token",
+	}, nil)
+	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user1").Return(&domain.User{
+		ID:     "user1",
+		Email:  "pending@test.com",
+		Status: domain.UserStatusPending,
+	}, nil)
+
+	req := httptest.NewRequest("GET", "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "invalid_token", resp["error"])
+}
+
+func TestUserInfoHandler_SAToken(t *testing.T) {
+	router, ctrl, mockTokenSvc, _ := setupUserInfoTest(t)
+	defer ctrl.Finish()
+
+	mockTokenSvc.EXPECT().ValidateAccessToken(gomock.Any(), "sa-token").Return(&domain.Token{
+		UserID:    "sa-issuer",
+		TokenType: "service_account_jwt",
+	}, nil)
+
+	req := httptest.NewRequest("GET", "/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer sa-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+
+	var resp sssoapi.UserInfo
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "sa-issuer", resp.Sub)
+	assert.Nil(t, resp.Email, "SA token should not have email field")
+}


### PR DESCRIPTION
## Summary

Implements the OIDC UserInfo endpoint at `GET/POST /oauth2/userinfo`, enabling Grafana (and any OIDC client) to authenticate via Shadow SSO.

## Changes

- **`api/openidv2_1/handlers.go`**: Filled the `UserInfoHandler` stub (previously returning 501) with:
  - Bearer token validation via `tokenService.ValidateAccessToken()`
  - Full OIDC UserInfo claims: `sub`, `email`, `email_verified`, `name`, `given_name`, `family_name`, `preferred_username`
  - Service account token handling (minimal `sub`-only response)
  - User status check (rejects locked/pending users with 401)
  - `Cache-Control: no-store` header per OIDC spec §5.3.2
  - Both GET and POST route registration
- **`api/openidv2_1/handlers_test.go`**: 9 unit tests covering success (GET/POST), missing/invalid tokens, user not found, locked/pending users, and SA tokens

## Testing

```
go test ./api/openidv2_1/ -run UserInfoHandler -v
```

All 9 tests pass. All existing tests continue to pass.

## Next steps

- Merge this PR
- Configure Grafana with OIDC pointing to Shadow SSO endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `/oauth2/userinfo` endpoint for retrieving authenticated user information.
  * Supports both GET and POST requests with bearer access tokens.
  * Returns user profile details for active users and subject-only information for service-account tokens.
  * Includes cache-prevention headers on successful responses.

* **Bug Fixes**
  * Invalid, missing, expired, or unauthorized tokens now return consistent `401 invalid_token` responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->