### PR TITLE
feat: OAuth 2.0 device flow — sssoctl CLI login, branded verify page, flow-less login, MFA completion

### DIFF
--- a/api/openidv2_1/handlers.go
+++ b/api/openidv2_1/handlers.go
@@ -169,15 +169,6 @@ func (oa *OAuth2API) RegisterRoutes(e *gin.Engine) {
 	// Client JWKS endpoints
 	e.GET("/clients/:clientId/jwks", oa.ClientJWKSHandler)
 
-	// Device Verification User-Facing Endpoints
-	deviceGroup := e.Group("/oauth2/device")
-	{
-		// Assuming some auth middleware (e.g., EnsureAuthenticated) might be applied to this group or individual routes.
-		// For this subtask, handlers will manually check for userID in context.
-		deviceGroup.GET("/verify", oa.DeviceVerificationPageHandler)
-		deviceGroup.POST("/verify", oa.DeviceVerificationSubmitHandler)
-	}
-
 	// API Endpoints for Next.js UI driven OIDC flow
 	oidcAPIGroup := e.Group("/api/oidc")
 	{
@@ -194,48 +185,6 @@ func (oa *OAuth2API) RegisterRoutes(e *gin.Engine) {
 }
 
 // ... (DeviceAuthorizationHandler, TokenHandler, handleDeviceCodeGrant, etc. - no changes here) ...
-
-const deviceVerificationHTML = `
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Activate Device</title>
-    <style>
-        body { font-family: sans-serif; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 90vh; background-color: #f4f4f4; color: #333; }
-        .container { background-color: #fff; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); text-align: center; }
-        input[type="text"] { padding: 10px; margin-bottom: 15px; border: 1px solid #ddd; border-radius: 4px; width: calc(100%% - 22px); }
-        button { padding: 10px 20px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; }
-        button:hover { background-color: #0056b3; }
-        .message { margin-top: 20px; padding: 10px; border-radius: 4px; }
-        .error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb;}
-        .success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb;}
-        .user-code-display { font-size: 1.2em; font-weight: bold; margin-bottom: 15px; color: #555; }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h2>Activate Device</h2>
-        <p>Please enter the code displayed on your device.</p>
-        {{if .UserCodePreFill}}
-        <p class="user-code-display">Code: {{.UserCodePreFill}}</p>
-        <form method="POST" action="/oauth2/device/verify">
-            <input type="hidden" name="user_code" value="{{.UserCodePreFill}}" />
-            <button type="submit">Confirm Activation</button>
-        </form>
-        {{else}}
-        <form method="POST" action="/oauth2/device/verify">
-            <input type="text" name="user_code" placeholder="Enter code (e.g., ABCD-EFGH)" required autofocus />
-            <button type="submit">Submit</button>
-        </form>
-        {{end}}
-        {{if .Message}}
-        <div class="message {{.MessageType}}">{{.Message}}</div>
-        {{end}}
-    </div>
-</body>
-</html>`
-
-var deviceVerificationTemplate = template.Must(template.New("deviceVerify").Parse(deviceVerificationHTML))
 
 const federatedErrorHTML = `
 <!DOCTYPE html>
@@ -350,120 +299,6 @@ func extractRawState(state string) string {
 		return parts[1]
 	}
 	return ""
-}
-
-// DeviceVerificationPageHandler serves the HTML page for user to enter their device code.
-// It can optionally pre-fill the user_code if provided as a query parameter.
-func (oa *OAuth2API) DeviceVerificationPageHandler(c *gin.Context) {
-	// This endpoint must be accessed by an authenticated user.
-	// For now, we'll simulate checking for a userID. A real app uses middleware.
-	_, userIDExists := c.Get("userID") // Example: userID set by auth middleware
-	if !userIDExists {
-		// In a real app, redirect to login page with a `return_to` parameter.
-		// For now, show an error or a simplified login prompt.
-		log.Warn().Msg("DeviceVerificationPageHandler: User not authenticated. Cannot display verification page.")
-		c.HTML(http.StatusUnauthorized, "deviceVerify", gin.H{
-			"Message":     "You must be logged in to activate a device.",
-			"MessageType": "error",
-		})
-		return
-	}
-
-	userCode := c.Query("user_code") // Allow pre-filling from query param e.g. /device/verify?user_code=XXXX-YYYY
-
-	c.Header("Content-Type", "text/html; charset=utf-8")
-	data := gin.H{
-		"UserCodePreFill": userCode,
-	}
-	err := deviceVerificationTemplate.Execute(c.Writer, data)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to render device verification page template")
-		c.String(http.StatusInternalServerError, "Error rendering page")
-	}
-}
-
-// DeviceVerificationSubmitHandler handles the submission of the device code by the user.
-func (oa *OAuth2API) DeviceVerificationSubmitHandler(c *gin.Context) {
-	userCode := c.PostForm("user_code")
-	if userCode == "" {
-		c.Header("Content-Type", "text/html; charset=utf-8")
-		err := deviceVerificationTemplate.Execute(c.Writer, gin.H{
-			"Message":     "User code cannot be empty.",
-			"MessageType": "error",
-		})
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to render template for empty user code")
-		}
-		return
-	}
-
-	// This endpoint MUST be accessed by an authenticated user.
-	// The userID should be available from the session or a JWT token processed by middleware.
-	// Example: userID, ok := c.Get("userID").(string)
-	userIDVal, userIDExists := c.Get("userID") // Assume userID is string
-	if !userIDExists {
-		log.Error().Msg("DeviceVerificationSubmitHandler: User not authenticated. Cannot verify code.")
-		c.Header("Content-Type", "text/html; charset=utf-8")
-		err := deviceVerificationTemplate.Execute(c.Writer, gin.H{
-			"UserCodePreFill": userCode, // Keep the code in the form
-			"Message":         "Authentication required. Please log in to activate your device.",
-			"MessageType":     "error",
-		})
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to render template for auth required")
-		}
-		return
-	}
-	userID, ok := userIDVal.(string)
-	if !ok || userID == "" {
-		log.Error().Interface("userIDVal", userIDVal).Msg("DeviceVerificationSubmitHandler: UserID is not a string or is empty.")
-		c.Header("Content-Type", "text/html; charset=utf-8")
-		err := deviceVerificationTemplate.Execute(c.Writer, gin.H{
-			"UserCodePreFill": userCode,
-			"Message":         "Invalid user session. Please log in again.",
-			"MessageType":     "error",
-		})
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to render template for invalid session")
-		}
-		return
-	}
-
-	ctx := c.Request.Context()
-	_, err := oa.service.VerifyUserCode(ctx, userCode, userID)
-
-	renderData := gin.H{"UserCodePreFill": userCode} // Keep code in display if re-showing form context
-
-	if err != nil {
-		log.Warn().Err(err).Str("userID", userID).Msg("Failed to verify user code")
-		renderData["MessageType"] = "error"
-		if goerrors.Is(err, domain.ErrUserCodeNotFound) {
-			renderData["Message"] = "Invalid or expired code. Please check the code and try again."
-		} else if goerrors.Is(err, domain.ErrCannotApproveDeviceAuth) {
-			// This might mean it was already used, or status wasn't pending.
-			renderData["Message"] = "This code cannot be used. It might have already been activated or is invalid."
-		} else {
-			renderData["Message"] = "An unexpected error occurred. Please try again later."
-		}
-		c.Header("Content-Type", "text/html; charset=utf-8")
-		tmplErr := deviceVerificationTemplate.Execute(c.Writer, renderData)
-		if tmplErr != nil {
-			log.Error().Err(tmplErr).Msg("Failed to render template for verification error")
-		}
-		return
-	}
-
-	log.Info().Str("user_code", userCode).Str("userID", userID).Msg("Device code successfully verified and linked to user.")
-	renderData["MessageType"] = "success"
-	renderData["Message"] = "Device activated successfully! You can now return to your device."
-	// Optionally, remove UserCodePreFill if success, so form is clear if they land here again.
-	renderData["UserCodePreFill"] = ""
-
-	c.Header("Content-Type", "text/html; charset=utf-8")
-	tmplErr := deviceVerificationTemplate.Execute(c.Writer, renderData)
-	if tmplErr != nil {
-		log.Error().Err(tmplErr).Msg("Failed to render template for verification success")
-	}
 }
 
 // DeviceAuthorizationHandler handles POST /oauth2/device_authorization

--- a/api/webauth/device.go
+++ b/api/webauth/device.go
@@ -1,0 +1,170 @@
+package webauth
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pilab-dev/shadow-sso/domain"
+	"github.com/rs/zerolog/log"
+)
+
+// deviceVerifyPath is the route path served by the device verification page.
+const deviceVerifyPath = "/oauth2/device/verify"
+
+// deviceLoginRedirectURL builds the login redirect that returns the user to
+// the device verification page (with the code preserved) after authenticating.
+func deviceLoginRedirectURL(userCode string) string {
+	verifyPath := deviceVerifyPath
+	if userCode != "" {
+		verifyPath += "?user_code=" + url.QueryEscape(userCode)
+	}
+	return "/login?return_to=" + url.QueryEscape(verifyPath)
+}
+
+// deviceErrorText maps a device-code verification failure to the user-facing
+// message, mirroring the strings previously used by the openidv2_1 handler.
+func deviceErrorText(err error) string {
+	switch {
+	case errors.Is(err, domain.ErrUserCodeNotFound):
+		return "Invalid or expired code. Please check the code and try again."
+	case errors.Is(err, domain.ErrCannotApproveDeviceAuth):
+		return "This code cannot be used. It might have already been activated or is invalid."
+	default:
+		return "An unexpected error occurred. Please try again later."
+	}
+}
+
+// DeviceVerificationPageHandler serves GET /oauth2/device/verify. Authenticated
+// users see the code and the requesting application with Approve/Deny actions;
+// unauthenticated users are redirected to /login and returned here afterwards.
+func (wa *WebAuth) DeviceVerificationPageHandler(c *gin.Context) {
+	userCode := c.Query("user_code")
+
+	if _, err := GetSSOSession(c.Request, wa.ssoCookieSecret); err != nil {
+		c.Redirect(http.StatusFound, deviceLoginRedirectURL(userCode))
+		return
+	}
+
+	data := gin.H{
+		"UserCode":    userCode,
+		"ClientName":  "an application",
+		"Message":     "",
+		"MessageType": "",
+	}
+
+	if userCode != "" {
+		if wa.deviceAuthRepo == nil {
+			log.Error().Msg("device: deviceAuthRepo is nil")
+			c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+				"PageTitle": "Error",
+				"Message":   "Device authorization is not available. Please try again later.",
+			})
+			return
+		}
+
+		dc, err := wa.deviceAuthRepo.GetDeviceAuthByUserCode(c.Request.Context(), userCode)
+		if err != nil {
+			if errors.Is(err, domain.ErrUserCodeNotFound) {
+				log.Warn().Str("user_code", userCode).Msg("device: code not found")
+				data["Message"] = deviceErrorText(domain.ErrUserCodeNotFound)
+				data["MessageType"] = "error"
+			} else {
+				log.Error().Err(err).Str("user_code", userCode).Msg("device: failed to load device code")
+				c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+					"PageTitle": "Error",
+					"Message":   "Failed to load device authorization. Please try again.",
+				})
+				return
+			}
+		} else if dc != nil {
+			if client, cErr := wa.clientService.GetClient(c.Request.Context(), dc.ClientID); cErr == nil && client != nil && client.Name != "" {
+				data["ClientName"] = client.Name
+			}
+		}
+	}
+
+	wa.renderTemplate(c, "device.html", data)
+}
+
+// DeviceVerificationSubmitHandler processes POST /oauth2/device/verify. It
+// validates CSRF, requires an authenticated session, then approves the code via
+// VerifyUserCode or denies it via UpdateDeviceAuthStatus.
+func (wa *WebAuth) DeviceVerificationSubmitHandler(c *gin.Context) {
+	if !validateCSRFTokenForm(c) {
+		c.HTML(http.StatusBadRequest, "error.html", gin.H{
+			"PageTitle": "Error",
+			"Message":   "Invalid form submission. Please try again.",
+		})
+		return
+	}
+
+	userCode := c.PostForm("user_code")
+	action := c.PostForm("action")
+
+	session, err := GetSSOSession(c.Request, wa.ssoCookieSecret)
+	if err != nil || len(session.Accounts) == 0 {
+		c.Redirect(http.StatusFound, deviceLoginRedirectURL(userCode))
+		return
+	}
+	userID := session.Accounts[0].UserID
+
+	ctx := c.Request.Context()
+
+	if action == "deny" {
+		if wa.deviceAuthRepo == nil {
+			log.Error().Msg("device: deviceAuthRepo is nil on deny")
+			c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+				"PageTitle": "Error",
+				"Message":   "Device authorization is not available. Please try again later.",
+			})
+			return
+		}
+
+		dc, dErr := wa.deviceAuthRepo.GetDeviceAuthByUserCode(ctx, userCode)
+		if dErr != nil || dc == nil {
+			log.Warn().Err(dErr).Str("user_code", userCode).Msg("device: code not found on deny")
+			wa.renderTemplate(c, "device.html", gin.H{
+				"UserCode":    userCode,
+				"Message":     deviceErrorText(domain.ErrUserCodeNotFound),
+				"MessageType": "error",
+			})
+			return
+		}
+		if uErr := wa.deviceAuthRepo.UpdateDeviceAuthStatus(ctx, dc.DeviceCode, domain.DeviceCodeStatusDenied); uErr != nil {
+			log.Error().Err(uErr).Str("device_code", dc.DeviceCode).Msg("device: failed to deny device code")
+			wa.renderTemplate(c, "device.html", gin.H{
+				"UserCode":    userCode,
+				"Message":     deviceErrorText(uErr),
+				"MessageType": "error",
+			})
+			return
+		}
+
+		log.Info().Str("device_code", dc.DeviceCode).Str("user_id", userID).Msg("device: access denied by user")
+		wa.renderTemplate(c, "device.html", gin.H{
+			"UserCode":    userCode,
+			"Message":     "Device access denied.",
+			"MessageType": "success",
+		})
+		return
+	}
+
+	if _, vErr := wa.oauthService.VerifyUserCode(ctx, userCode, userID); vErr != nil {
+		log.Warn().Err(vErr).Str("user_code", userCode).Str("user_id", userID).Msg("device: failed to verify user code")
+		wa.renderTemplate(c, "device.html", gin.H{
+			"UserCode":    userCode,
+			"Message":     deviceErrorText(vErr),
+			"MessageType": "error",
+		})
+		return
+	}
+
+	log.Info().Str("user_code", userCode).Str("user_id", userID).Msg("device: code verified and linked to user")
+	wa.renderTemplate(c, "device.html", gin.H{
+		"UserCode":    userCode,
+		"Message":     "Device activated successfully! You can now return to your device.",
+		"MessageType": "success",
+	})
+}

--- a/api/webauth/device_test.go
+++ b/api/webauth/device_test.go
@@ -1,0 +1,289 @@
+package webauth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pilab-dev/shadow-sso/api/webauth"
+	"github.com/pilab-dev/shadow-sso/domain"
+	mock_domain "github.com/pilab-dev/shadow-sso/domain/mocks"
+	"github.com/pilab-dev/shadow-sso/internal/ssosession"
+	services_mocks "github.com/pilab-dev/shadow-sso/services/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	deviceTestSSOCookieSecret = "test-secret-32-bytes-long-for-hmac-sha256!!"
+	testCSRFToken       = "test-csrf-token"
+)
+
+// setupDeviceTest wires the device verification routes with gomock-backed deps.
+func setupDeviceTest(t *testing.T) (
+	*gin.Engine,
+	*gomock.Controller,
+	*mock_domain.MockDeviceAuthorizationRepository,
+	*services_mocks.MockOAuthService,
+	*services_mocks.MockClientService,
+) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+
+	mockDeviceAuthRepo := mock_domain.NewMockDeviceAuthorizationRepository(ctrl)
+	mockOAuthService := services_mocks.NewMockOAuthService(ctrl)
+	mockClientService := services_mocks.NewMockClientService(ctrl)
+
+	wa := webauth.New(&webauth.Options{
+		OAuthService:    mockOAuthService,
+		ClientService:   mockClientService,
+		DeviceAuthRepo:  mockDeviceAuthRepo,
+		Config:          webauth.DefaultConfig(),
+		SSOCookieSecret: deviceTestSSOCookieSecret,
+	})
+
+	router := gin.New()
+	router.LoadHTMLGlob("templates/*.html")
+	router.GET("/oauth2/device/verify", wa.DeviceVerificationPageHandler)
+	router.POST("/oauth2/device/verify", wa.DeviceVerificationSubmitHandler)
+
+	return router, ctrl, mockDeviceAuthRepo, mockOAuthService, mockClientService
+}
+
+// authenticatedSessionCookie builds a valid signed sso_session cookie for the
+// given user, mirroring what a completed login would set.
+func authenticatedSessionCookie(t *testing.T, userID string) *http.Cookie {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	session := &ssosession.Session{
+		SessionID: ssosession.NewID(),
+		Accounts: []ssosession.Account{{
+			UserID:   userID,
+			Email:    "user@example.com",
+			Name:     "Test User",
+			LastUsed: time.Now(),
+		}},
+	}
+	require.NoError(t, webauth.SetSSOSessionCookie(rec, session, false, deviceTestSSOCookieSecret))
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == ssosession.CookieName {
+			return c
+		}
+	}
+	t.Fatal("expected sso_session cookie to be set")
+	return nil
+}
+
+// authenticatedRequest returns a GET request carrying the signed session and a
+// matching CSRF cookie so both session auth and form CSRF are satisfied.
+func authenticatedRequest(t *testing.T, method, path string, form url.Values) *http.Request {
+	t.Helper()
+	var req *http.Request
+	if form != nil {
+		req = httptest.NewRequest(method, path, strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	req.AddCookie(authenticatedSessionCookie(t, "user-1"))
+	req.AddCookie(&http.Cookie{Name: webauth.CSRFCookieName, Value: testCSRFToken})
+	return req
+}
+
+func TestDeviceVerifyPage_UnauthenticatedRedirectsToLogin(t *testing.T) {
+	// Given an unauthenticated request with a user code
+	router, ctrl, _, _, _ := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	// When the verification page is requested
+	req := httptest.NewRequest("GET", "/oauth2/device/verify?user_code=ABCD-EFGH", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the user is redirected to /login with the return_to preserving the code
+	require.Equal(t, http.StatusFound, w.Code)
+	loc := w.Header().Get("Location")
+	assert.True(t, strings.HasPrefix(loc, "/login?return_to="), "Location = %q", loc)
+	unescaped, err := url.QueryUnescape(strings.TrimPrefix(loc, "/login?return_to="))
+	require.NoError(t, err)
+	assert.Equal(t, "/oauth2/device/verify?user_code=ABCD-EFGH", unescaped)
+}
+
+func TestDeviceVerifyPage_UnauthenticatedWithoutCodeRedirectsToPlainVerify(t *testing.T) {
+	// Given an unauthenticated request without a user code
+	router, ctrl, _, _, _ := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	// When the verification page is requested
+	req := httptest.NewRequest("GET", "/oauth2/device/verify", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the user is redirected to /login with a plain verify return_to
+	require.Equal(t, http.StatusFound, w.Code)
+	loc := w.Header().Get("Location")
+	assert.True(t, strings.HasPrefix(loc, "/login?return_to="), "Location = %q", loc)
+	unescaped, err := url.QueryUnescape(strings.TrimPrefix(loc, "/login?return_to="))
+	require.NoError(t, err)
+	assert.Equal(t, "/oauth2/device/verify", unescaped)
+}
+
+func TestDeviceVerifyPage_AuthenticatedWithValidCode(t *testing.T) {
+	// Given an authenticated user and a pending device code for a known client
+	router, ctrl, mockDeviceAuthRepo, _, mockClientService := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	mockDeviceAuthRepo.EXPECT().GetDeviceAuthByUserCode(gomock.Any(), "ABCD-EFGH").Return(
+		&domain.DeviceCode{DeviceCode: "dev-123", UserCode: "ABCD-EFGH", ClientID: "sssoctl", Status: domain.DeviceCodeStatusPending},
+		nil,
+	)
+	mockClientService.EXPECT().GetClient(gomock.Any(), "sssoctl").Return(&domain.Client{Name: "ssoctl CLI"}, nil)
+
+	// When the verification page is requested with the code
+	req := authenticatedRequest(t, "GET", "/oauth2/device/verify?user_code=ABCD-EFGH", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the page shows the code and the requesting application
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "ABCD-EFGH")
+	assert.Contains(t, body, "ssoctl CLI")
+	assert.Contains(t, body, "Approve")
+	assert.Contains(t, body, "Deny")
+}
+
+func TestDeviceVerifyPage_AuthenticatedWithoutCode(t *testing.T) {
+	// Given an authenticated user with no user code prefilled
+	router, ctrl, _, _, _ := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	// When the verification page is requested without a code
+	req := authenticatedRequest(t, "GET", "/oauth2/device/verify", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the page renders with an empty code entry field and no crash
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `name="user_code"`)
+	assert.Contains(t, body, "Activate Device")
+}
+
+func TestDeviceVerifyPage_UnknownCodeShowsErrorState(t *testing.T) {
+	// Given an authenticated user and a code that does not exist
+	router, ctrl, mockDeviceAuthRepo, _, _ := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	mockDeviceAuthRepo.EXPECT().GetDeviceAuthByUserCode(gomock.Any(), "GHIJ-KLMN").Return(nil, domain.ErrUserCodeNotFound)
+
+	// When the verification page is requested with the unknown code
+	req := authenticatedRequest(t, "GET", "/oauth2/device/verify?user_code=GHIJ-KLMN", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the page renders an error state without panicking
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid or expired code")
+}
+
+func TestDeviceVerifySubmit_ApproveSuccess(t *testing.T) {
+	// Given an authenticated user and a valid pending code
+	router, ctrl, _, mockOAuthService, _ := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	mockOAuthService.EXPECT().VerifyUserCode(gomock.Any(), "ABCD-EFGH", "user-1").Return(
+		&domain.DeviceCode{DeviceCode: "dev-123", UserCode: "ABCD-EFGH", Status: domain.DeviceCodeStatusAuthorized},
+		nil,
+	)
+
+	// When the user approves the code
+	form := url.Values{"user_code": {"ABCD-EFGH"}, "action": {"approve"}, "csrf_token": {testCSRFToken}}
+	req := authenticatedRequest(t, "POST", "/oauth2/device/verify", form)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the page confirms activation
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Device activated successfully")
+}
+
+func TestDeviceVerifySubmit_ApproveInvalidCode(t *testing.T) {
+	// Given an authenticated user and a code the service cannot find
+	router, ctrl, _, mockOAuthService, _ := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	mockOAuthService.EXPECT().VerifyUserCode(gomock.Any(), "BAD-CODE", "user-1").Return(nil, domain.ErrUserCodeNotFound)
+
+	// When the user submits the invalid code
+	form := url.Values{"user_code": {"BAD-CODE"}, "action": {"approve"}, "csrf_token": {testCSRFToken}}
+	req := authenticatedRequest(t, "POST", "/oauth2/device/verify", form)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the page shows the mapped error message
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid or expired code")
+}
+
+func TestDeviceVerifySubmit_Deny(t *testing.T) {
+	// Given an authenticated user and a pending device code
+	router, ctrl, mockDeviceAuthRepo, _, _ := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	mockDeviceAuthRepo.EXPECT().GetDeviceAuthByUserCode(gomock.Any(), "ABCD-EFGH").Return(
+		&domain.DeviceCode{DeviceCode: "dev-123", UserCode: "ABCD-EFGH", ClientID: "sssoctl"},
+		nil,
+	)
+	mockDeviceAuthRepo.EXPECT().UpdateDeviceAuthStatus(gomock.Any(), "dev-123", domain.DeviceCodeStatusDenied).Return(nil)
+
+	// When the user denies the code
+	form := url.Values{"user_code": {"ABCD-EFGH"}, "action": {"deny"}, "csrf_token": {testCSRFToken}}
+	req := authenticatedRequest(t, "POST", "/oauth2/device/verify", form)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the code is marked denied and the page confirms it
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Device access denied.")
+}
+
+func TestDeviceVerifySubmit_MissingCSRFRejected(t *testing.T) {
+	// Given an authenticated user but no CSRF token
+	router, ctrl, _, _, _ := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	// When a POST arrives without the CSRF token
+	form := url.Values{"user_code": {"ABCD-EFGH"}, "action": {"approve"}}
+	req := httptest.NewRequest("POST", "/oauth2/device/verify", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(authenticatedSessionCookie(t, "user-1"))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the submission is rejected with 400
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid form submission")
+}
+
+func TestDeviceVerifySubmit_InvalidCSRFRejected(t *testing.T) {
+	// Given an authenticated user and a mismatched CSRF token
+	router, ctrl, _, _, _ := setupDeviceTest(t)
+	defer ctrl.Finish()
+
+	// When a POST arrives with a wrong CSRF token
+	form := url.Values{"user_code": {"ABCD-EFGH"}, "action": {"approve"}, "csrf_token": {"wrong-token"}}
+	req := authenticatedRequest(t, "POST", "/oauth2/device/verify", form)
+	req.AddCookie(&http.Cookie{Name: webauth.CSRFCookieName, Value: "other-token"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then the submission is rejected with 400
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/api/webauth/login.go
+++ b/api/webauth/login.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pilab-dev/shadow-sso/domain"
 	"github.com/pilab-dev/shadow-sso/internal/ssosession"
 	"github.com/rs/zerolog/log"
@@ -45,6 +46,37 @@ func (wa *WebAuth) LoginPageHandler(c *gin.Context) {
 	flowID := GetFlowIDFromCookie(c.Request)
 
 	if flowID == "" {
+		// Flow-less login: when no sso_oidc_flow_id cookie exists but a
+		// validated same-origin return_to is present (e.g. the device
+		// verification redirect), start a synthetic flow so the login page
+		// renders instead of failing with 400.
+		if rt := c.Query("return_to"); rt != "" && validReturnTo(rt) {
+			ctx := c.Request.Context()
+			flowID = uuid.NewString()
+			flowState := &domain.LoginFlowState{
+				FlowID:    flowID,
+				ExpiresAt: time.Now().Add(syntheticFlowLifetime),
+			}
+			if err := wa.flowStore.StoreFlow(ctx, flowID, *flowState); err != nil {
+				log.Error().Err(err).Str("flow_id", flowID).Msg("login: failed to store synthetic flow")
+				c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+					"PageTitle": "Error",
+					"Message":   "Internal error. Please try again.",
+				})
+				return
+			}
+			isSecure := IsSecureRequest(c.Request)
+			setFlowCookie(c.Writer, flowID, isSecure)
+			setReturnToCookie(c.Writer, rt, isSecure, wa.ssoCookieSecret)
+
+			providers, err := wa.idpRepo.ListIdPs(ctx, true)
+			if err != nil {
+				log.Error().Err(err).Msg("login: failed to load identity providers")
+				providers = nil
+			}
+			wa.renderLoginPage(c, flowID, providers, "")
+			return
+		}
 		c.HTML(http.StatusBadRequest, "error.html", gin.H{
 			"PageTitle": "Error",
 			"Message":   "Missing login request identifier.",
@@ -286,6 +318,19 @@ func (wa *WebAuth) LoginSubmitHandler(c *gin.Context) {
 	}
 	if requiresConsent {
 		c.Redirect(http.StatusFound, "/consent?flow_id="+url.QueryEscape(flowID))
+		return
+	}
+	if flowState.ClientID == "" {
+		// Flow-less login (no OIDC client): complete by redirecting to the
+		// signed return_to destination captured when the synthetic flow began.
+		// The cookie is cleared on use; fall back to "/" when absent or invalid.
+		rt := readReturnToCookie(c.Request, wa.ssoCookieSecret)
+		clearReturnToCookie(c.Writer, isSecure)
+		if rt != "" && validReturnTo(rt) {
+			c.Redirect(http.StatusFound, rt)
+			return
+		}
+		c.Redirect(http.StatusFound, "/")
 		return
 	}
 	c.Redirect(http.StatusFound, "/oauth2/authorize?flow_id="+url.QueryEscape(flowID))

--- a/api/webauth/login.go
+++ b/api/webauth/login.go
@@ -264,10 +264,22 @@ func (wa *WebAuth) LoginSubmitHandler(c *gin.Context) {
 			})
 			return
 		}
+		csrfToken, cErr := generateCSRFToken()
+		if cErr != nil {
+			log.Error().Err(cErr).Msg("login: failed to generate CSRF token")
+			c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+				"PageTitle": "Error",
+				"Message":   "Internal error. Please try again.",
+			})
+			return
+		}
+		isSecure := IsSecureRequest(c.Request)
+		setCSRFCookie(c.Writer, csrfToken, 10*time.Minute, isSecure)
 		c.HTML(http.StatusOK, "mfa.html", gin.H{
 			"PageTitle": "Two-Factor Authentication",
 			"FlowID":    flowID,
-			"UserID":    user.ID,
+			"CSRFToken": csrfToken,
+			"Error":     "",
 			"BrandName": wa.config.BrandOrganizationName,
 		})
 		return

--- a/api/webauth/login_returnto_test.go
+++ b/api/webauth/login_returnto_test.go
@@ -1,0 +1,250 @@
+package webauth_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pilab-dev/shadow-sso/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// testReturnToCookieSecret mirrors the SSOCookieSecret configured in
+// setupLoginTest so the tests can mint validly-signed sso_return_to cookies.
+const testReturnToCookieSecret = "test-secret-32-bytes-long-for-hmac-sha256!!"
+
+func signReturnToCookie(t *testing.T, returnTo string) string {
+	t.Helper()
+	payload := base64.RawURLEncoding.EncodeToString([]byte(returnTo))
+	mac := hmac.New(sha256.New, []byte(testReturnToCookieSecret))
+	mac.Write([]byte(returnTo))
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return payload + "." + signature
+}
+
+func findCookie(cookies []*http.Cookie, name string) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestLoginPage_FlowlessWithReturnTo: GET /login?return_to=... without a flow
+// cookie renders the login page (200, not 400), stores a synthetic flow, and
+// sets both the flow cookie and the signed return_to cookie.
+func TestLoginPage_FlowlessWithReturnTo(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, _, mockIdPRepo, _, _, _ := setupLoginTest(t)
+	defer ctrl.Finish()
+
+	wantReturnTo := "/oauth2/device/verify?user_code=ABCD-EFGH"
+	var storedFlowID string
+	mockFlowStore.EXPECT().StoreFlow(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, flowID string, _ domain.LoginFlowState) error {
+			storedFlowID = flowID
+			return nil
+		},
+	).Times(1)
+	mockIdPRepo.EXPECT().ListIdPs(gomock.Any(), true).Return([]*domain.IdentityProvider{}, nil)
+
+	// When
+	req := httptest.NewRequest("GET", "/login?return_to="+url.QueryEscape(wantReturnTo), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Sign in to your account")
+	require.NotEmpty(t, storedFlowID)
+
+	cookies := w.Result().Cookies()
+	flowCookie := findCookie(cookies, "sso_oidc_flow_id")
+	require.NotNil(t, flowCookie)
+	assert.Equal(t, storedFlowID, flowCookie.Value)
+	assert.True(t, flowCookie.HttpOnly)
+	assert.Equal(t, http.SameSiteLaxMode, flowCookie.SameSite)
+
+	rtCookie := findCookie(cookies, "sso_return_to")
+	require.NotNil(t, rtCookie)
+	assert.True(t, rtCookie.HttpOnly)
+	assert.Equal(t, http.SameSiteLaxMode, rtCookie.SameSite)
+	parts := strings.Split(rtCookie.Value, ".")
+	require.Len(t, parts, 2)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	assert.Equal(t, wantReturnTo, string(payload))
+}
+
+// TestLoginSubmit_FlowlessHappyPath: full POST with a synthetic (ClientID-less)
+// flow redirects to the exact signed return_to path and clears the cookie.
+func TestLoginSubmit_FlowlessHappyPath(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, mockUserRepo, _, mockPasswordHasher, _, _ := setupLoginTest(t)
+	defer ctrl.Finish()
+
+	wantReturnTo := "/oauth2/device/verify?user_code=ABCD-EFGH"
+	flowState := &domain.LoginFlowState{
+		FlowID:    "synthetic-flow",
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+	}
+	mockFlowStore.EXPECT().GetFlow(gomock.Any(), "synthetic-flow").Return(flowState, nil)
+	mockFlowStore.EXPECT().UpdateFlow(gomock.Any(), "synthetic-flow", gomock.Any()).Return(nil)
+
+	user := &domain.User{
+		ID:           "user-123",
+		Email:        "test@example.com",
+		PasswordHash: "hashed-password",
+		Status:       domain.UserStatusActive,
+	}
+	mockUserRepo.EXPECT().GetUserByEmail(gomock.Any(), "test@example.com").Return(user, nil)
+	mockPasswordHasher.EXPECT().Verify("hashed-password", "correct-password").Return(nil)
+
+	// When
+	form := url.Values{}
+	form.Set("csrf_token", "test-csrf")
+	form.Set("email", "test@example.com")
+	form.Set("password", "correct-password")
+
+	req := httptest.NewRequest("POST", "/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "sso_csrf_token", Value: "test-csrf"})
+	req.AddCookie(&http.Cookie{Name: "sso_oidc_flow_id", Value: "synthetic-flow"})
+	req.AddCookie(&http.Cookie{Name: "sso_return_to", Value: signReturnToCookie(t, wantReturnTo)})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, wantReturnTo, w.Header().Get("Location"))
+
+	rtCookie := findCookie(w.Result().Cookies(), "sso_return_to")
+	require.NotNil(t, rtCookie, "sso_return_to cookie must be cleared in the response")
+	assert.Empty(t, rtCookie.Value)
+	assert.LessOrEqual(t, rtCookie.MaxAge, 0)
+}
+
+// TestLoginPage_FlowlessInvalidReturnTo: GET /login?return_to=<evil> falls back
+// to the existing 400 error page and sets no flow/return_to cookies.
+func TestLoginPage_FlowlessInvalidReturnTo(t *testing.T) {
+	evils := []string{"//evil.com", "https://evil.com", "/../etc", `\evil`}
+	for _, evil := range evils {
+		t.Run(evil, func(t *testing.T) {
+			// Given
+			router, ctrl, _, _, _, _, _, _ := setupLoginTest(t)
+			defer ctrl.Finish()
+
+			// When
+			req := httptest.NewRequest("GET", "/login?return_to="+url.QueryEscape(evil), nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			// Then
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "Missing login request identifier")
+			for _, c := range w.Result().Cookies() {
+				assert.NotEqual(t, "sso_oidc_flow_id", c.Name)
+				assert.NotEqual(t, "sso_return_to", c.Name)
+			}
+		})
+	}
+}
+
+// TestLoginSubmit_FlowlessInvalidReturnToCookie: a signed-but-invalid
+// sso_return_to cookie value (would be an open redirect) redirects to "/"
+// instead of the evil destination.
+func TestLoginSubmit_FlowlessInvalidReturnToCookie(t *testing.T) {
+	evils := []string{"//evil.com", "https://evil.com", "/../etc", `\evil`}
+	for _, evil := range evils {
+		t.Run(evil, func(t *testing.T) {
+			// Given
+			router, ctrl, mockFlowStore, mockUserRepo, _, mockPasswordHasher, _, _ := setupLoginTest(t)
+			defer ctrl.Finish()
+
+			flowState := &domain.LoginFlowState{
+				FlowID:    "synthetic-flow",
+				ExpiresAt: time.Now().Add(15 * time.Minute),
+			}
+			mockFlowStore.EXPECT().GetFlow(gomock.Any(), "synthetic-flow").Return(flowState, nil)
+			mockFlowStore.EXPECT().UpdateFlow(gomock.Any(), "synthetic-flow", gomock.Any()).Return(nil)
+
+			user := &domain.User{
+				ID:           "user-123",
+				Email:        "test@example.com",
+				PasswordHash: "hashed-password",
+				Status:       domain.UserStatusActive,
+			}
+			mockUserRepo.EXPECT().GetUserByEmail(gomock.Any(), "test@example.com").Return(user, nil)
+			mockPasswordHasher.EXPECT().Verify("hashed-password", "correct-password").Return(nil)
+
+			// When
+			form := url.Values{}
+			form.Set("csrf_token", "test-csrf")
+			form.Set("email", "test@example.com")
+			form.Set("password", "correct-password")
+
+			req := httptest.NewRequest("POST", "/login", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.AddCookie(&http.Cookie{Name: "sso_csrf_token", Value: "test-csrf"})
+			req.AddCookie(&http.Cookie{Name: "sso_oidc_flow_id", Value: "synthetic-flow"})
+			req.AddCookie(&http.Cookie{Name: "sso_return_to", Value: signReturnToCookie(t, evil)})
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			// Then
+			require.Equal(t, http.StatusFound, w.Code)
+			assert.Equal(t, "/", w.Header().Get("Location"))
+		})
+	}
+}
+
+// TestLoginSubmit_FlowlessWithoutReturnToCookie: a synthetic flow without a
+// return_to cookie redirects to "/".
+func TestLoginSubmit_FlowlessWithoutReturnToCookie(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, mockUserRepo, _, mockPasswordHasher, _, _ := setupLoginTest(t)
+	defer ctrl.Finish()
+
+	flowState := &domain.LoginFlowState{
+		FlowID:    "synthetic-flow",
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+	}
+	mockFlowStore.EXPECT().GetFlow(gomock.Any(), "synthetic-flow").Return(flowState, nil)
+	mockFlowStore.EXPECT().UpdateFlow(gomock.Any(), "synthetic-flow", gomock.Any()).Return(nil)
+
+	user := &domain.User{
+		ID:           "user-123",
+		Email:        "test@example.com",
+		PasswordHash: "hashed-password",
+		Status:       domain.UserStatusActive,
+	}
+	mockUserRepo.EXPECT().GetUserByEmail(gomock.Any(), "test@example.com").Return(user, nil)
+	mockPasswordHasher.EXPECT().Verify("hashed-password", "correct-password").Return(nil)
+
+	// When
+	form := url.Values{}
+	form.Set("csrf_token", "test-csrf")
+	form.Set("email", "test@example.com")
+	form.Set("password", "correct-password")
+
+	req := httptest.NewRequest("POST", "/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "sso_csrf_token", Value: "test-csrf"})
+	req.AddCookie(&http.Cookie{Name: "sso_oidc_flow_id", Value: "synthetic-flow"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/", w.Header().Get("Location"))
+}

--- a/api/webauth/mfa.go
+++ b/api/webauth/mfa.go
@@ -1,0 +1,160 @@
+package webauth
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pilab-dev/shadow-sso/internal/auth/totp"
+	"github.com/pilab-dev/shadow-sso/internal/ssosession"
+	"github.com/rs/zerolog/log"
+)
+
+// MFASubmitHandler processes POST /mfa. It validates the TOTP code submitted
+// from mfa.html against the user recorded on the flow state during login, then
+// completes the flow:
+//   - real OIDC flows (ClientID set) redirect to /oauth2/authorize?flow_id=<id>,
+//     exactly like the non-MFA completion path in LoginSubmitHandler;
+//   - flow-less (synthetic, ClientID-less) logins redirect to the signed
+//     sso_return_to destination captured when the synthetic flow began, falling
+//     back to "/" when the cookie is absent or invalid.
+func (wa *WebAuth) MFASubmitHandler(c *gin.Context) {
+	if !validateCSRFTokenForm(c) {
+		c.HTML(http.StatusBadRequest, "error.html", gin.H{
+			"PageTitle": "Error",
+			"Message":   "Invalid or expired login request. Please try again.",
+		})
+		return
+	}
+
+	flowID := c.PostForm("flow_id")
+	if flowID == "" {
+		c.HTML(http.StatusBadRequest, "error.html", gin.H{
+			"PageTitle": "Error",
+			"Message":   "Invalid or expired login request. Please try again.",
+		})
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	flowState, err := wa.flowStore.GetFlow(ctx, flowID)
+	if err != nil {
+		log.Warn().Err(err).Str("flow_id", flowID).Msg("mfa: flow not found")
+		c.HTML(http.StatusBadRequest, "error.html", gin.H{
+			"PageTitle": "Error",
+			"Message":   "Invalid or expired login request. Please try again.",
+		})
+		return
+	}
+	if time.Now().After(flowState.ExpiresAt) {
+		log.Warn().Str("flow_id", flowID).Msg("mfa: flow expired")
+		_ = wa.flowStore.DeleteFlow(ctx, flowID)
+		c.HTML(http.StatusBadRequest, "error.html", gin.H{
+			"PageTitle": "Error",
+			"Message":   "Invalid or expired login request. Please try again.",
+		})
+		return
+	}
+
+	userID := flowState.UserID
+	if userID == "" {
+		log.Warn().Str("flow_id", flowID).Msg("mfa: no authenticated user in flow")
+		c.HTML(http.StatusBadRequest, "error.html", gin.H{
+			"PageTitle": "Error",
+			"Message":   "Invalid or expired login request. Please try again.",
+		})
+		return
+	}
+
+	user, err := wa.userRepo.GetUserByID(ctx, userID)
+	if err != nil {
+		log.Warn().Err(err).Str("flow_id", flowID).Str("user_id", userID).Msg("mfa: user not found")
+		c.HTML(http.StatusBadRequest, "error.html", gin.H{
+			"PageTitle": "Error",
+			"Message":   "Invalid or expired login request. Please try again.",
+		})
+		return
+	}
+
+	otp := c.PostForm("otp")
+	valid, err := totp.ValidateTOTPCode(user.TwoFactorSecret, otp)
+	if err != nil {
+		log.Error().Err(err).Str("flow_id", flowID).Msg("mfa: TOTP validation error")
+		c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+			"PageTitle": "Error",
+			"Message":   "Failed to verify the code. Please try again.",
+		})
+		return
+	}
+	if !valid {
+		log.Warn().Str("flow_id", flowID).Msg("mfa: invalid verification code")
+		csrfToken, tErr := generateCSRFToken()
+		if tErr != nil {
+			log.Error().Err(tErr).Msg("mfa: failed to generate CSRF token")
+			c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+				"PageTitle": "Error",
+				"Message":   "Internal error. Please try again.",
+			})
+			return
+		}
+		isSecure := IsSecureRequest(c.Request)
+		setCSRFCookie(c.Writer, csrfToken, 10*time.Minute, isSecure)
+		c.HTML(http.StatusOK, "mfa.html", gin.H{
+			"PageTitle": "Two-Factor Authentication",
+			"FlowID":    flowID,
+			"CSRFToken": csrfToken,
+			"Error":     "Invalid verification code. Please try again.",
+			"BrandName": wa.config.BrandOrganizationName,
+		})
+		return
+	}
+
+	displayName := user.Email
+	if user.FirstName != "" || user.LastName != "" {
+		displayName = fmt.Sprintf("%s %s", user.FirstName, user.LastName)
+	}
+	isSecure := IsSecureRequest(c.Request)
+	session := &ssosession.Session{
+		SessionID: ssosession.NewID(),
+		Accounts: []ssosession.Account{{
+			UserID:   user.ID,
+			Email:    user.Email,
+			Name:     displayName,
+			LastUsed: time.Now(),
+		}},
+	}
+	if err := SetSSOSessionCookie(c.Writer, session, isSecure, wa.ssoCookieSecret); err != nil {
+		log.Error().Err(err).Msg("mfa: failed to set SSO session cookie")
+		c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+			"PageTitle": "Error",
+			"Message":   "Failed to create session. Please try again.",
+		})
+		return
+	}
+
+	flowState.UserID = user.ID
+	if flowState.UserAuthenticatedAt.IsZero() {
+		flowState.UserAuthenticatedAt = time.Now()
+	}
+	if err := wa.flowStore.UpdateFlow(ctx, flowID, flowState); err != nil {
+		log.Error().Err(err).Str("flow_id", flowID).Msg("mfa: failed to update flow state")
+	}
+
+	if flowState.ClientID == "" {
+		// Flow-less login (no OIDC client): complete by redirecting to the
+		// signed return_to destination captured when the synthetic flow began.
+		// The cookie is cleared on use; fall back to "/" when absent or invalid.
+		rt := readReturnToCookie(c.Request, wa.ssoCookieSecret)
+		clearReturnToCookie(c.Writer, isSecure)
+		if rt != "" && validReturnTo(rt) {
+			c.Redirect(http.StatusFound, rt)
+			return
+		}
+		c.Redirect(http.StatusFound, "/")
+		return
+	}
+	c.Redirect(http.StatusFound, "/oauth2/authorize?flow_id="+url.QueryEscape(flowID))
+}

--- a/api/webauth/mfa_test.go
+++ b/api/webauth/mfa_test.go
@@ -1,0 +1,327 @@
+package webauth_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pilab-dev/shadow-sso/api/webauth"
+	"github.com/pilab-dev/shadow-sso/domain"
+	mock_domain "github.com/pilab-dev/shadow-sso/domain/mocks"
+	totp2fa "github.com/pilab-dev/shadow-sso/internal/auth/totp"
+	otptotp "github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// setupMFATest wires the POST /mfa route with gomock-backed deps. It reuses the
+// testReturnToCookieSecret const declared in login_returnto_test.go (same
+// package) so signed sso_return_to cookies minted by signReturnToCookie verify.
+func setupMFATest(t *testing.T) (
+	*gin.Engine,
+	*gomock.Controller,
+	*mock_domain.MockFlowStore,
+	*mock_domain.MockUserRepository,
+) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+
+	mockFlowStore := mock_domain.NewMockFlowStore(ctrl)
+	mockUserRepo := mock_domain.NewMockUserRepository(ctrl)
+
+	wa := webauth.New(&webauth.Options{
+		UserRepo:        mockUserRepo,
+		PasswordHasher:  mock_domain.NewMockPasswordHasher(ctrl),
+		FlowStore:       mockFlowStore,
+		Config:          webauth.DefaultConfig(),
+		SSOCookieSecret: testReturnToCookieSecret,
+	})
+
+	router := gin.New()
+	router.LoadHTMLGlob("templates/*.html")
+	router.POST("/mfa", wa.MFASubmitHandler)
+
+	return router, ctrl, mockFlowStore, mockUserRepo
+}
+
+// mfaTestSecret generates a fresh TOTP secret (base32 string) to store on the
+// mocked user, mirroring how internal/auth/totp produces secrets.
+func mfaTestSecret(t *testing.T) string {
+	t.Helper()
+	key, _, err := totp2fa.GenerateTOTPSecret("shadow-sso", "test@example.com")
+	require.NoError(t, err)
+	return key.Secret()
+}
+
+// mfaTestCode returns the current valid TOTP code for the given secret.
+func mfaTestCode(t *testing.T, secret string) string {
+	t.Helper()
+	code, err := otptotp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+	return code
+}
+
+// mfaRequest builds a POST /mfa request carrying the CSRF cookie + form token
+// and any extra cookies (e.g. a signed sso_return_to cookie).
+func mfaRequest(t *testing.T, flowID, csrf, code string, extra ...*http.Cookie) *http.Request {
+	t.Helper()
+	form := url.Values{}
+	form.Set("csrf_token", csrf)
+	form.Set("flow_id", flowID)
+	form.Set("otp", code)
+
+	req := httptest.NewRequest("POST", "/mfa", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: webauth.CSRFCookieName, Value: csrf})
+	for _, c := range extra {
+		req.AddCookie(c)
+	}
+	return req
+}
+
+// mfaFlowState returns a valid, in-date flow state with an authenticated user.
+func mfaFlowState(flowID string) *domain.LoginFlowState {
+	return &domain.LoginFlowState{
+		FlowID:    flowID,
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+		UserID:    "user-123",
+	}
+}
+
+// TestMFASubmit_SyntheticFlowRedirectsToReturnTo: a ClientID-less (flow-less)
+// flow with a signed sso_return_to cookie and a valid TOTP code redirects to
+// the exact return_to path and clears the cookie.
+func TestMFASubmit_SyntheticFlowRedirectsToReturnTo(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, mockUserRepo := setupMFATest(t)
+	defer ctrl.Finish()
+
+	wantReturnTo := "/oauth2/device/verify?user_code=ABCD-EFGH"
+	flowState := mfaFlowState("mfa-flow")
+	mockFlowStore.EXPECT().GetFlow(gomock.Any(), "mfa-flow").Return(flowState, nil)
+	mockFlowStore.EXPECT().UpdateFlow(gomock.Any(), "mfa-flow", gomock.Any()).Return(nil)
+
+	secret := mfaTestSecret(t)
+	user := &domain.User{ID: "user-123", Email: "test@example.com", TwoFactorSecret: secret}
+	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user-123").Return(user, nil)
+
+	// When
+	req := mfaRequest(t, "mfa-flow", "test-csrf", mfaTestCode(t, secret),
+		&http.Cookie{Name: webauth.ReturnToCookieName, Value: signReturnToCookie(t, wantReturnTo)})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, wantReturnTo, w.Header().Get("Location"))
+
+	rtCookie := findCookie(w.Result().Cookies(), webauth.ReturnToCookieName)
+	require.NotNil(t, rtCookie, "sso_return_to cookie must be cleared in the response")
+	assert.Empty(t, rtCookie.Value)
+	assert.LessOrEqual(t, rtCookie.MaxAge, 0)
+}
+
+// TestMFASubmit_SyntheticFlowWithoutReturnToCookie: a synthetic flow without a
+// return_to cookie redirects to "/".
+func TestMFASubmit_SyntheticFlowWithoutReturnToCookie(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, mockUserRepo := setupMFATest(t)
+	defer ctrl.Finish()
+
+	mockFlowStore.EXPECT().GetFlow(gomock.Any(), "mfa-flow").Return(mfaFlowState("mfa-flow"), nil)
+	mockFlowStore.EXPECT().UpdateFlow(gomock.Any(), "mfa-flow", gomock.Any()).Return(nil)
+
+	secret := mfaTestSecret(t)
+	user := &domain.User{ID: "user-123", Email: "test@example.com", TwoFactorSecret: secret}
+	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user-123").Return(user, nil)
+
+	// When
+	req := mfaRequest(t, "mfa-flow", "test-csrf", mfaTestCode(t, secret))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/", w.Header().Get("Location"))
+}
+
+// TestMFASubmit_RealOIDCFlowRedirectsToAuthorize: a real OIDC flow (ClientID
+// set) with a valid TOTP code redirects to /oauth2/authorize?flow_id=<id>,
+// exactly as the non-MFA completion path does.
+func TestMFASubmit_RealOIDCFlowRedirectsToAuthorize(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, mockUserRepo := setupMFATest(t)
+	defer ctrl.Finish()
+
+	flowState := mfaFlowState("oidc-flow")
+	flowState.ClientID = "sssoctl"
+	flowState.RedirectURI = "http://localhost:8080/callback"
+	mockFlowStore.EXPECT().GetFlow(gomock.Any(), "oidc-flow").Return(flowState, nil)
+	mockFlowStore.EXPECT().UpdateFlow(gomock.Any(), "oidc-flow", gomock.Any()).Return(nil)
+
+	secret := mfaTestSecret(t)
+	user := &domain.User{ID: "user-123", Email: "test@example.com", TwoFactorSecret: secret}
+	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user-123").Return(user, nil)
+
+	// When
+	req := mfaRequest(t, "oidc-flow", "test-csrf", mfaTestCode(t, secret))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/oauth2/authorize?flow_id=oidc-flow", w.Header().Get("Location"))
+}
+
+// TestMFASubmit_InvalidTOTPCode: a wrong code re-renders mfa.html (200) with an
+// error message and does NOT redirect.
+func TestMFASubmit_InvalidTOTPCode(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, mockUserRepo := setupMFATest(t)
+	defer ctrl.Finish()
+
+	mockFlowStore.EXPECT().GetFlow(gomock.Any(), "mfa-flow").Return(mfaFlowState("mfa-flow"), nil)
+
+	secret := mfaTestSecret(t)
+	user := &domain.User{ID: "user-123", Email: "test@example.com", TwoFactorSecret: secret}
+	mockUserRepo.EXPECT().GetUserByID(gomock.Any(), "user-123").Return(user, nil)
+
+	// When - submit a definitely-wrong code
+	req := mfaRequest(t, "mfa-flow", "test-csrf", "000000")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid verification code. Please try again.")
+	assert.Empty(t, w.Header().Get("Location"), "invalid code must not redirect")
+}
+
+// TestMFASubmit_MissingCSRF: a POST without a CSRF cookie/token is rejected
+// with 400.
+func TestMFASubmit_MissingCSRF(t *testing.T) {
+	// Given
+	router, ctrl, _, _ := setupMFATest(t)
+	defer ctrl.Finish()
+
+	// When - no CSRF cookie at all
+	form := url.Values{}
+	form.Set("flow_id", "mfa-flow")
+	form.Set("otp", "123456")
+	req := httptest.NewRequest("POST", "/mfa", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid or expired login request")
+}
+
+// TestMFASubmit_InvalidCSRF: a POST with a mismatched CSRF cookie/token is
+// rejected with 400.
+func TestMFASubmit_InvalidCSRF(t *testing.T) {
+	// Given
+	router, ctrl, _, _ := setupMFATest(t)
+	defer ctrl.Finish()
+
+	// When - cookie value differs from the form token
+	form := url.Values{}
+	form.Set("csrf_token", "expected-token")
+	form.Set("flow_id", "mfa-flow")
+	form.Set("otp", "123456")
+	req := httptest.NewRequest("POST", "/mfa", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: webauth.CSRFCookieName, Value: "different-token"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestMFASubmit_UnknownFlow: an unknown flow_id is rejected with 400.
+func TestMFASubmit_UnknownFlow(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, _ := setupMFATest(t)
+	defer ctrl.Finish()
+
+	mockFlowStore.EXPECT().GetFlow(gomock.Any(), "unknown-flow").Return(nil, errors.New("flow not found"))
+
+	// When
+	req := mfaRequest(t, "unknown-flow", "test-csrf", "123456")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid or expired login request")
+}
+
+// TestMFASubmit_ExpiredFlow: an expired flow is rejected with 400 and the flow
+// is deleted best-effort.
+func TestMFASubmit_ExpiredFlow(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, _ := setupMFATest(t)
+	defer ctrl.Finish()
+
+	flowState := mfaFlowState("expired-flow")
+	flowState.ExpiresAt = time.Now().Add(-10 * time.Minute)
+	mockFlowStore.EXPECT().GetFlow(gomock.Any(), "expired-flow").Return(flowState, nil)
+	mockFlowStore.EXPECT().DeleteFlow(gomock.Any(), "expired-flow").Return(nil)
+
+	// When
+	req := mfaRequest(t, "expired-flow", "test-csrf", "123456")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid or expired login request")
+}
+
+// TestMFASubmit_MissingFlowID: a POST without a flow_id is rejected with 400.
+func TestMFASubmit_MissingFlowID(t *testing.T) {
+	// Given
+	router, ctrl, _, _ := setupMFATest(t)
+	defer ctrl.Finish()
+
+	// When
+	req := mfaRequest(t, "", "test-csrf", "123456")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid or expired login request")
+}
+
+// TestMFASubmit_NoUserIDInFlow: a valid flow without an authenticated user is
+// rejected with 400 (login never completed the password step).
+func TestMFASubmit_NoUserIDInFlow(t *testing.T) {
+	// Given
+	router, ctrl, mockFlowStore, _ := setupMFATest(t)
+	defer ctrl.Finish()
+
+	flowState := &domain.LoginFlowState{
+		FlowID:    "mfa-flow",
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+	}
+	mockFlowStore.EXPECT().GetFlow(gomock.Any(), "mfa-flow").Return(flowState, nil)
+
+	// When
+	req := mfaRequest(t, "mfa-flow", "test-csrf", "123456")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Then
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid or expired login request")
+}

--- a/api/webauth/security.go
+++ b/api/webauth/security.go
@@ -1,7 +1,11 @@
 package webauth
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -20,6 +24,13 @@ const (
 	// FlowCookieName is the name of the cookie carrying the server-side flow ID.
 	// The client never sees this value — it is only read from the cookie.
 	FlowCookieName = "sso_oidc_flow_id"
+	// ReturnToCookieName is the name of the signed cookie carrying the
+	// validated same-origin destination for flow-less logins. The return_to
+	// value travels in this cookie (HMAC-signed), never in a form field.
+	ReturnToCookieName = "sso_return_to"
+	// syntheticFlowLifetime is the expiry of synthetic (ClientID-less) login
+	// flows and their sso_oidc_flow_id / sso_return_to cookies.
+	syntheticFlowLifetime = 15 * time.Minute
 )
 
 // ---------------------------------------------------------------------------
@@ -170,4 +181,99 @@ func GetFlowIDFromCookie(r *http.Request) string {
 		return ""
 	}
 	return cookie.Value
+}
+
+// ---------------------------------------------------------------------------
+// Flow-less login (return_to) helpers
+// ---------------------------------------------------------------------------
+
+// validReturnTo guards against open redirects: only same-origin, root-relative
+// paths are accepted. Absolute URLs (http/https), protocol-relative URLs (//),
+// backslash escapes, and dot-segment traversal (/../) are rejected.
+func validReturnTo(rt string) bool {
+	return strings.HasPrefix(rt, "/") &&
+		!strings.HasPrefix(rt, "//") &&
+		!strings.Contains(rt, "\\") &&
+		!strings.HasPrefix(rt, "http://") &&
+		!strings.HasPrefix(rt, "https://") &&
+		!strings.Contains(rt, "/../")
+}
+
+// setFlowCookie sets the sso_oidc_flow_id cookie with the same attributes the
+// OIDC authorize flow uses, so GetFlowIDFromCookie reads it back.
+func setFlowCookie(w http.ResponseWriter, flowID string, isSecure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     FlowCookieName,
+		Value:    flowID,
+		Path:     "/",
+		MaxAge:   int(syntheticFlowLifetime.Seconds()),
+		HttpOnly: true,
+		Secure:   isSecure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// setReturnToCookie signs the return_to value with the cookie signing secret
+// (HMAC-SHA256 over the raw value, base64url payload.signature — the same
+// scheme the sso_session cookie uses) and stores it in an HttpOnly,
+// SameSite=Lax cookie.
+func setReturnToCookie(w http.ResponseWriter, returnTo string, isSecure bool, secret string) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(returnTo))
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(returnTo))
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     ReturnToCookieName,
+		Value:    payload + "." + signature,
+		Path:     "/",
+		MaxAge:   int(syntheticFlowLifetime.Seconds()),
+		HttpOnly: true,
+		Secure:   isSecure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// readReturnToCookie verifies the signature of the sso_return_to cookie and
+// returns the return_to value, or "" when the cookie is missing, malformed,
+// or the signature does not verify.
+func readReturnToCookie(r *http.Request, secret string) string {
+	cookie, err := r.Cookie(ReturnToCookieName)
+	if err != nil || cookie.Value == "" {
+		return ""
+	}
+
+	dotIdx := strings.LastIndexByte(cookie.Value, '.')
+	if dotIdx <= 0 || dotIdx == len(cookie.Value)-1 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(cookie.Value[:dotIdx])
+	if err != nil {
+		return ""
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(cookie.Value[dotIdx+1:])
+	if err != nil {
+		return ""
+	}
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	if subtle.ConstantTimeCompare(signature, mac.Sum(nil)) != 1 {
+		return ""
+	}
+	return string(payload)
+}
+
+// clearReturnToCookie immediately expires the sso_return_to cookie. It is
+// called after the destination has been consumed on login completion.
+func clearReturnToCookie(w http.ResponseWriter, isSecure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     ReturnToCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   isSecure,
+		SameSite: http.SameSiteLaxMode,
+	})
 }

--- a/api/webauth/templates/device.html
+++ b/api/webauth/templates/device.html
@@ -1,0 +1,60 @@
+{{template "base_start" .}}
+<h2 class="page-title">Activate Device</h2>
+<p class="page-subtitle">Approve this request to sign in on your device</p>
+
+{{if .Message}}
+<div class="alert {{if eq .MessageType "success"}}alert-success{{else}}alert-error{{end}}" role="alert">
+    <span class="alert-icon">
+        {{if eq .MessageType "success"}}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+        {{else}}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        {{end}}
+    </span>
+    <span>{{.Message}}</span>
+</div>
+{{end}}
+
+<div class="info-box">
+    <p class="info-box-title">Requesting application</p>
+    <p style="font-size:0.9375rem;color:var(--text);">{{if .ClientName}}{{.ClientName}}{{else}}an application{{end}}</p>
+</div>
+
+<form method="POST" action="/oauth2/device/verify">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+
+    {{if .UserCode}}
+    <div class="info-box" style="text-align:center;">
+        <p class="info-box-title">Your code</p>
+        <p class="otp-input" style="font-size:1.25rem;letter-spacing:0.25em;">{{.UserCode}}</p>
+    </div>
+    <input type="hidden" name="user_code" value="{{.UserCode}}">
+    {{else}}
+    <div class="form-group">
+        <label for="user_code" class="form-label">Device code</label>
+        <input
+            type="text"
+            id="user_code"
+            name="user_code"
+            class="form-input"
+            placeholder="Enter the code from your device (e.g., ABCD-EFGH)"
+            required
+            autofocus
+        >
+    </div>
+    {{end}}
+
+    <div class="actions">
+        <button type="submit" name="action" value="approve" class="btn btn-primary">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+            Approve
+        </button>
+        <button type="submit" name="action" value="deny" class="btn btn-danger">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>
+            Deny
+        </button>
+    </div>
+</form>
+
+<p class="page-subtitle" style="margin-top:16px;">The code expires shortly after it is shown on your device.</p>
+{{template "base_end" .}}

--- a/api/webauth/webauth.go
+++ b/api/webauth/webauth.go
@@ -17,37 +17,43 @@ var templatesFS embed.FS
 // WebAuth holds all dependencies for the server-side web authentication UI.
 // Methods for handling login, consent, and social flows will be added in subsequent todos.
 type WebAuth struct {
-	userRepo           domain.UserRepository
-	passwordHasher     domain.PasswordHasher
-	flowStore          domain.FlowStore
-	userSessionStore   domain.UserSessionStore
-	idpRepo            domain.IdPRepository
-	federationService  services.FederationService
-	oauthService       services.OAuthService
-	tokenService       services.TokenService
-	clientService      services.ClientService
-	config             *Config
-	ssoCookieSecret    string
-	rateLimiter        *RateLimiter
-	runner             *authflow.Runner
-	realmSettingsRepo  domain.RealmSettingsRepository
+	userRepo          domain.UserRepository
+	passwordHasher    domain.PasswordHasher
+	flowStore         domain.FlowStore
+	userSessionStore  domain.UserSessionStore
+	idpRepo           domain.IdPRepository
+	federationService services.FederationService
+	oauthService      services.OAuthService
+	tokenService      services.TokenService
+	clientService     services.ClientService
+	config            *Config
+	ssoCookieSecret   string
+	rateLimiter       *RateLimiter
+	runner            *authflow.Runner
+	realmSettingsRepo domain.RealmSettingsRepository
+	// deviceAuthRepo backs the device authorization flow verification UI.
+	// It is nil-safe: consumers MUST check for nil and degrade gracefully
+	// (e.g. render an error page) rather than panic when unset.
+	deviceAuthRepo domain.DeviceAuthorizationRepository
 }
 
 // Options configures the WebAuth instance with all required dependencies.
 type Options struct {
-	UserRepo           domain.UserRepository
-	PasswordHasher     domain.PasswordHasher
-	FlowStore          domain.FlowStore
-	UserSessionStore   domain.UserSessionStore
-	IdPRepository      domain.IdPRepository
-	FederationService  services.FederationService
-	OAuthService       services.OAuthService
-	TokenService       services.TokenService
-	ClientService      services.ClientService
-	Config             *Config
-	SSOCookieSecret    string
-	AuthFlowRepo       domain.AuthenticationFlowRepository
-	RealmSettingsRepo  domain.RealmSettingsRepository
+	UserRepo          domain.UserRepository
+	PasswordHasher    domain.PasswordHasher
+	FlowStore         domain.FlowStore
+	UserSessionStore  domain.UserSessionStore
+	IdPRepository     domain.IdPRepository
+	FederationService services.FederationService
+	OAuthService      services.OAuthService
+	TokenService      services.TokenService
+	ClientService     services.ClientService
+	Config            *Config
+	SSOCookieSecret   string
+	AuthFlowRepo      domain.AuthenticationFlowRepository
+	RealmSettingsRepo domain.RealmSettingsRepository
+	// DeviceAuthRepo is optional; when nil, device-flow handlers must not panic.
+	DeviceAuthRepo domain.DeviceAuthorizationRepository
 }
 
 // New creates a new WebAuth instance with the provided dependencies.
@@ -73,6 +79,7 @@ func New(opts *Options) *WebAuth {
 		rateLimiter:       NewRateLimiter(cfg.RateLimitMaxAttempts, cfg.RateLimitLockoutDuration),
 		runner:            authflow.NewRunner(opts.AuthFlowRepo, opts.PasswordHasher),
 		realmSettingsRepo: opts.RealmSettingsRepo,
+		deviceAuthRepo:    opts.DeviceAuthRepo,
 	}
 }
 

--- a/apps/ssso/config/config.go
+++ b/apps/ssso/config/config.go
@@ -51,6 +51,9 @@ type Config struct {
 	// Configuration service encryption key
 	ConfigEncryptionKey string `mapstructure:"config_encryption_key"`
 
+	// HMAC signing secret for the ssosession (s_session) cookie
+	CookieSigningSecret string `mapstructure:"cookie_signing_secret"`
+
 	// Token signing
 	TokenSigningKey     string `mapstructure:"token_signing_key"`
 	TokenSigningKeyFile string `mapstructure:"token_signing_key_file"`
@@ -192,6 +195,7 @@ func LoadConfig() (config Config, err error) {
 	viper.SetDefault("key_rotation_interval", "24h")
 	viper.SetDefault("default_redirect_uri", "http://localhost:3000/login")
 	viper.SetDefault("token_cache_default_ttl", "1h")
+	viper.SetDefault("cookie_signing_secret", "")
 	// signing_key_path has no default, should be provided or generated on first run.
 	// nextjs_login_url has no default, should be configured if UI flow is used.
 
@@ -240,6 +244,7 @@ func LoadConfig() (config Config, err error) {
 	// Explicitly bind env vars so viper.Unmarshal picks them up
 	_ = viper.BindEnv("mgmt_http_addr")
 	_ = viper.BindEnv("config_encryption_key")
+	_ = viper.BindEnv("cookie_signing_secret")
 	_ = viper.BindEnv("signing_key_path")
 	viper.BindEnv("token_signing_key")
 	viper.BindEnv("initial_admin_enabled")
@@ -280,6 +285,18 @@ func LoadConfig() (config Config, err error) {
 		}
 		config.ConfigEncryptionKey = hex.EncodeToString(key)
 		log.Warn().Msgf("No SSSO_CONFIG_ENCRYPTION_KEY set — auto-generated ephemeral key for dev session (SSSO_ALLOW_INSECURE_DEFAULTS=true): %s", config.ConfigEncryptionKey)
+	}
+
+	if config.CookieSigningSecret == "" {
+		if !config.AllowInsecureDefaults {
+			return Config{}, fmt.Errorf("FATAL: cookie_signing_secret is required. Set SSSO_COOKIE_SIGNING_SECRET environment variable (or set SSSO_ALLOW_INSECURE_DEFAULTS=true for local development only)")
+		}
+		key := make([]byte, 32)
+		if _, err := rand.Read(key); err != nil {
+			return Config{}, fmt.Errorf("failed to generate cookie signing secret: %w", err)
+		}
+		config.CookieSigningSecret = hex.EncodeToString(key)
+		log.Warn().Msg("No SSSO_COOKIE_SIGNING_SECRET set — auto-generated ephemeral secret for dev session (SSSO_ALLOW_INSECURE_DEFAULTS=true)")
 	}
 
 	// Viper doesn't automatically convert string to custom types like StorageType

--- a/apps/ssso/config/config_test.go
+++ b/apps/ssso/config/config_test.go
@@ -26,11 +26,13 @@ func resetConfigEnv(t *testing.T) {
 	os.Unsetenv("SSSO_DTS_CONNECT_TIMEOUT")
 	os.Unsetenv("SSSO_DTS_DEFAULT_PKCE_TTL")
 	os.Unsetenv("SSSO_CONFIG_ENCRYPTION_KEY")
+	os.Unsetenv("SSSO_COOKIE_SIGNING_SECRET")
 }
 
 func TestLoadConfig_Defaults(t *testing.T) {
 	resetConfigEnv(t)
 	t.Setenv("SSSO_CONFIG_ENCRYPTION_KEY", "test-encryption-key-32bytes-long!!")
+	t.Setenv("SSSO_COOKIE_SIGNING_SECRET", "test-cookie-signing-secret")
 
 	cfg, err := config.LoadConfig()
 	require.NoError(t, err)
@@ -51,6 +53,7 @@ func TestLoadConfig_Defaults(t *testing.T) {
 func TestLoadConfig_EnvOverrides(t *testing.T) {
 	resetConfigEnv(t)
 	t.Setenv("SSSO_CONFIG_ENCRYPTION_KEY", "test-encryption-key-32bytes-long!!")
+	t.Setenv("SSSO_COOKIE_SIGNING_SECRET", "test-cookie-signing-secret")
 
 	// Set environment variables
 	os.Setenv("SSSO_HTTP_ADDR", "127.0.0.1:9090")
@@ -98,6 +101,7 @@ func TestLoadConfig_EnvOverrides(t *testing.T) {
 func TestLoadConfig_InvalidStorageBackend(t *testing.T) {
 	resetConfigEnv(t)
 	t.Setenv("SSSO_CONFIG_ENCRYPTION_KEY", "test-encryption-key-32bytes-long!!")
+	t.Setenv("SSSO_COOKIE_SIGNING_SECRET", "test-cookie-signing-secret")
 	os.Setenv("SSSO_STORAGE_BACKEND", "invalid_backend")
 	defer os.Unsetenv("SSSO_STORAGE_BACKEND")
 
@@ -137,4 +141,24 @@ func TestLoadConfig_InvalidDuration(t *testing.T) {
 	// If Unmarshal fails due to duration parsing, err will be non-nil.
 	// If it silently uses default, err is nil and value is default.
 	require.Error(t, err, "Expected error due to invalid duration")
+}
+
+func TestLoadConfig_CookieSigningSecretOverride(t *testing.T) {
+	resetConfigEnv(t)
+	t.Setenv("SSSO_CONFIG_ENCRYPTION_KEY", "test-encryption-key-32bytes-long!!")
+	t.Setenv("SSSO_COOKIE_SIGNING_SECRET", "custom-secret-value-123")
+
+	cfg, err := config.LoadConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom-secret-value-123", cfg.CookieSigningSecret)
+}
+
+func TestLoadConfig_MissingCookieSigningSecret_FailsClosed(t *testing.T) {
+	resetConfigEnv(t)
+	t.Setenv("SSSO_CONFIG_ENCRYPTION_KEY", "test-encryption-key-32bytes-long!!")
+
+	_, err := config.LoadConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cookie_signing_secret")
 }

--- a/apps/ssso/server/start.go
+++ b/apps/ssso/server/start.go
@@ -191,11 +191,12 @@ func StartServer(ctx context.Context, cfg config.Config, repoProvider services.R
 			}
 			return cache.NewMemoryTokenStore(oidcConfig.AccessTokenTTL)
 		}(),
-		PkceRepository:   nil, // Let NewSSOServer default to in-memory
-		FlowStore:        nil, // Let NewSSOServer default to in-memory
-		UserSessionStore: nil, // Let NewSSOServer default to in-memory
-		EncryptionKey:    encryptionKey,
-		ExtraMiddlewares: nil,
+		PkceRepository:      nil, // Let NewSSOServer default to in-memory
+		FlowStore:           nil, // Let NewSSOServer default to in-memory
+		UserSessionStore:    nil, // Let NewSSOServer default to in-memory
+		EncryptionKey:       encryptionKey,
+		CookieSigningSecret: cfg.CookieSigningSecret,
+		ExtraMiddlewares:    nil,
 	}
 
 	// Apply functional options

--- a/apps/sssoctl/cmd/auth.go
+++ b/apps/sssoctl/cmd/auth.go
@@ -45,6 +45,19 @@ var loginCmd = &cobra.Command{
 			}
 		}
 
+		// Device flow login: RFC 8628 device authorization grant. Does not use gRPC.
+		if useDeviceFlow, err := cmd.Flags().GetBool("device"); err == nil && useDeviceFlow {
+			deviceLoginClientID, err = cmd.Flags().GetString("client-id")
+			if err != nil {
+				return fmt.Errorf("failed to read --client-id flag: %w", err)
+			}
+			deviceLoginScope, err = cmd.Flags().GetString("scope")
+			if err != nil {
+				return fmt.Errorf("failed to read --scope flag: %w", err)
+			}
+			return runDeviceLogin(currentCtx)
+		}
+
 		fmt.Print("Enter email: ")
 		reader := bufio.NewReader(os.Stdin)
 		email, _ := reader.ReadString('\n')
@@ -135,4 +148,7 @@ func init() {
 	authCmd.AddCommand(loginCmd)
 	authCmd.AddCommand(logoutCmd)
 	// loginCmd can have flags for --endpoint, --username, etc. to override context or for non-interactive login
+	loginCmd.Flags().Bool("device", false, "Use the OAuth 2.0 device authorization flow (RFC 8628) instead of gRPC login")
+	loginCmd.Flags().String("client-id", "sssoctl", "OAuth client ID to use for device flow login")
+	loginCmd.Flags().String("scope", "openid profile email", "Space-separated OAuth scopes to request for device flow login")
 }

--- a/apps/sssoctl/cmd/device_flow.go
+++ b/apps/sssoctl/cmd/device_flow.go
@@ -1,0 +1,269 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/pilab-dev/shadow-sso/apps/sssoctl/cmd/config"
+)
+
+const deviceGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
+const (
+	deviceCodeAuthPending  = "authorization_pending"
+	deviceCodeSlowDown     = "slow_down"
+	deviceCodeExpiredToken = "expired_token"
+	deviceCodeAccessDenied = "access_denied"
+	deviceCodeInvalidGrant = "invalid_grant"
+)
+
+// deviceLoginClientID and deviceLoginScope carry the --client-id/--scope flag
+// values from loginCmd's RunE into runDeviceLogin. runDeviceLogin cannot read
+// them from loginCmd directly: that would create a package initialization
+// cycle (loginCmd's initializer references runDeviceLogin).
+var (
+	deviceLoginClientID string
+	deviceLoginScope    string
+)
+
+type deviceAuthResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete,omitempty"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval,omitempty"`
+}
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	IDToken      string `json:"id_token,omitempty"`
+}
+
+type tokenErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+func runDeviceLogin(currentCtx *config.Context) error {
+	clientID := deviceLoginClientID
+	scope := deviceLoginScope
+
+	base := strings.TrimRight(currentCtx.ServerEndpoint, "/")
+	if base == "" {
+		return errors.New("server endpoint is empty; set one with 'ssoctl config set-context <name> --server <endpoint>'")
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+
+	authResp, err := initiateDeviceAuthorization(context.Background(), base, clientID, scope, httpClient.Do)
+	if err != nil {
+		return err
+	}
+
+	uri := authResp.VerificationURI
+	if authResp.VerificationURIComplete != "" {
+		uri = authResp.VerificationURIComplete
+	}
+	fmt.Printf("Open the following URL in your browser:\n  %s\nand enter the code: %s\n", uri, authResp.UserCode)
+	openBrowser(uri)
+
+	interval := time.Duration(authResp.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+
+	pollCtx, cancel := context.WithTimeout(context.Background(), time.Duration(authResp.ExpiresIn+30)*time.Second)
+	defer cancel()
+	tokenResp, err := pollForTokenResponse(pollCtx, base, authResp.DeviceCode, clientID, interval, "", httpClient.Do)
+	if err != nil {
+		return err
+	}
+
+	currentCtx.UserAuthToken = tokenResp.AccessToken
+	config.GlobalConfig.Contexts[config.GlobalConfig.CurrentContext] = currentCtx
+	if err := config.SaveConfig(); err != nil {
+		return fmt.Errorf("failed to save token to config: %w", err)
+	}
+
+	fmt.Printf("Login successful. Token saved for context '%s'.\n", config.GlobalConfig.CurrentContext)
+	if email := idTokenEmail(tokenResp.IDToken); email != "" {
+		fmt.Printf("Logged in as: %s\n", email)
+	}
+	return nil
+}
+
+func initiateDeviceAuthorization(ctx context.Context, base, clientID, scope string, httpDo func(*http.Request) (*http.Response, error)) (*deviceAuthResponse, error) {
+	form := url.Values{}
+	form.Set("client_id", clientID)
+	if scope != "" {
+		form.Set("scope", scope)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(base, "/")+"/oauth2/device_authorization", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build device authorization request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpDo(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to contact device authorization endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read device authorization response: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		var errResp tokenErrorResponse
+		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("device authorization failed: %s: %s", errResp.Error, errResp.ErrorDescription)
+		}
+		return nil, fmt.Errorf("device authorization failed (HTTP %s): %s", resp.Status, bodyExcerpt(body))
+	}
+
+	var authResp deviceAuthResponse
+	if err := json.Unmarshal(body, &authResp); err != nil {
+		return nil, fmt.Errorf("invalid device authorization response: %w (body: %s)", err, bodyExcerpt(body))
+	}
+	if authResp.DeviceCode == "" || authResp.UserCode == "" {
+		return nil, errors.New("device authorization response is missing device_code or user_code")
+	}
+	return &authResp, nil
+}
+
+func pollForToken(ctx context.Context, base, deviceCode, clientID string, interval time.Duration, tokenURL string, httpDo func(*http.Request) (*http.Response, error)) (string, error) {
+	tokenResp, err := pollForTokenResponse(ctx, base, deviceCode, clientID, interval, tokenURL, httpDo)
+	if err != nil {
+		return "", err
+	}
+	return tokenResp.AccessToken, nil
+}
+
+func pollForTokenResponse(ctx context.Context, base, deviceCode, clientID string, interval time.Duration, tokenURL string, httpDo func(*http.Request) (*http.Response, error)) (*tokenResponse, error) {
+	if tokenURL == "" {
+		tokenURL = strings.TrimRight(base, "/") + "/oauth2/token"
+	}
+	for {
+		tokenResp, errResp, err := pollOnce(ctx, tokenURL, deviceCode, clientID, httpDo)
+		if err != nil {
+			return nil, err
+		}
+		if tokenResp != nil {
+			return tokenResp, nil
+		}
+
+		switch errResp.Error {
+		case deviceCodeAuthPending:
+			if err := sleepWithContext(ctx, interval); err != nil {
+				return nil, err
+			}
+		case deviceCodeSlowDown:
+			interval += 5 * time.Second
+			if err := sleepWithContext(ctx, interval); err != nil {
+				return nil, err
+			}
+		case deviceCodeExpiredToken, deviceCodeInvalidGrant:
+			return nil, fmt.Errorf("device code expired - please try again")
+		case deviceCodeAccessDenied:
+			return nil, errors.New("access denied by user")
+		default:
+			return nil, fmt.Errorf("token endpoint error: %s: %s", errResp.Error, errResp.ErrorDescription)
+		}
+	}
+}
+
+func pollOnce(ctx context.Context, tokenURL, deviceCode, clientID string, httpDo func(*http.Request) (*http.Response, error)) (*tokenResponse, *tokenErrorResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", deviceGrantType)
+	form.Set("device_code", deviceCode)
+	form.Set("client_id", clientID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpDo(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to poll token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read token response: %w", err)
+	}
+
+	var tokenResp tokenResponse
+	if json.Unmarshal(body, &tokenResp) == nil && tokenResp.AccessToken != "" {
+		return &tokenResp, nil, nil
+	}
+
+	var errResp tokenErrorResponse
+	if json.Unmarshal(body, &errResp) != nil || errResp.Error == "" {
+		return nil, nil, fmt.Errorf("unexpected token endpoint response: %s", bodyExcerpt(body))
+	}
+	return nil, &errResp, nil
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return errors.New("timed out waiting for device authorization - please try again")
+	case <-timer.C:
+		return nil
+	}
+}
+
+func openBrowser(uri string) {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "darwin" {
+		cmd = exec.Command("open", uri)
+	} else {
+		cmd = exec.Command("xdg-open", uri)
+	}
+	_ = cmd.Start()
+}
+
+func idTokenEmail(idToken string) string {
+	parts := strings.Split(idToken, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if json.Unmarshal(payload, &claims) != nil {
+		return ""
+	}
+	return claims.Email
+}
+
+func bodyExcerpt(body []byte) string {
+	const maxLen = 200
+	if len(body) > maxLen {
+		return string(body[:maxLen]) + "..."
+	}
+	return string(body)
+}

--- a/apps/sssoctl/cmd/device_flow_test.go
+++ b/apps/sssoctl/cmd/device_flow_test.go
@@ -1,0 +1,263 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func tokenSuccessBody(accessToken string) map[string]any {
+	return map[string]any{
+		"access_token":  accessToken,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+		"refresh_token": "rt-1",
+		"id_token":      "header.payload.signature",
+	}
+}
+
+// (a) happy: first poll authorization_pending, second access_token -> returns token.
+func TestPollForToken_HappyPath(t *testing.T) {
+	var mu sync.Mutex
+	polls := 0
+	var bodies []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		if r.URL.Path != "/oauth2/token" {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "not_found"})
+			return
+		}
+		mu.Lock()
+		polls++
+		first := polls == 1
+		mu.Unlock()
+		if first {
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error":             "authorization_pending",
+				"error_description": "authorization pending",
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, tokenSuccessBody("at-1"))
+	}))
+	defer srv.Close()
+
+	token, err := pollForToken(context.Background(), "", "dev-code-1", "sssoctl", time.Millisecond, srv.URL+"/oauth2/token", srv.Client().Do)
+	if err != nil {
+		t.Fatalf("pollForToken returned error: %v", err)
+	}
+	if token != "at-1" {
+		t.Fatalf("expected token at-1, got %q", token)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if polls != 2 {
+		t.Fatalf("expected 2 polls, got %d", polls)
+	}
+	for _, b := range bodies {
+		form, err := url.ParseQuery(b)
+		if err != nil {
+			t.Fatalf("poll body is not a valid form: %q: %v", b, err)
+		}
+		if form.Get("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" {
+			t.Errorf("expected device_code grant_type in %q", b)
+		}
+		if form.Get("device_code") != "dev-code-1" || form.Get("client_id") != "sssoctl" {
+			t.Errorf("expected device_code and client_id in %q", b)
+		}
+	}
+}
+
+// (b) slow_down increments the polling interval by 5s before the retry.
+func TestPollForToken_SlowDownIncrementsInterval(t *testing.T) {
+	var mu sync.Mutex
+	requestTimes := []time.Time{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestTimes = append(requestTimes, time.Now())
+		first := len(requestTimes) == 1
+		mu.Unlock()
+		if first {
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error":             "slow_down",
+				"error_description": "slow down",
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, tokenSuccessBody("at-2"))
+	}))
+	defer srv.Close()
+
+	token, err := pollForToken(context.Background(), "", "dev-code-1", "sssoctl", time.Millisecond, srv.URL+"/oauth2/token", srv.Client().Do)
+	if err != nil {
+		t.Fatalf("pollForToken returned error: %v", err)
+	}
+	if token != "at-2" {
+		t.Fatalf("expected token at-2, got %q", token)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestTimes) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(requestTimes))
+	}
+	// slow_down adds 5s to the (1ms) interval, so the retry must arrive >= 5s later.
+	if elapsed := requestTimes[1].Sub(requestTimes[0]); elapsed < 5*time.Second {
+		t.Errorf("expected retry at least 5s after slow_down, got %v", elapsed)
+	}
+}
+
+// (c) expired_token and invalid_grant fail with an error mentioning "expired".
+func TestPollForToken_ExpiredCode(t *testing.T) {
+	for _, serverErr := range []string{"expired_token", "invalid_grant"} {
+		t.Run(serverErr, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusBadRequest, map[string]string{
+					"error":             serverErr,
+					"error_description": "the code has expired",
+				})
+			}))
+			defer srv.Close()
+
+			_, err := pollForToken(context.Background(), "", "dev-code-1", "sssoctl", time.Millisecond, srv.URL+"/oauth2/token", srv.Client().Do)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "expired") {
+				t.Errorf("expected error mentioning 'expired', got: %v", err)
+			}
+		})
+	}
+}
+
+// (d) access_denied fails with an error mentioning "denied".
+func TestPollForToken_AccessDenied(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":             "access_denied",
+			"error_description": "user denied the request",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := pollForToken(context.Background(), "", "dev-code-1", "sssoctl", time.Millisecond, srv.URL+"/oauth2/token", srv.Client().Do)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "denied") {
+		t.Errorf("expected error mentioning 'denied', got: %v", err)
+	}
+}
+
+// (e) device_authorization returning 401 invalid_client yields a friendly error.
+func TestInitiateDeviceAuthorization_InvalidClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth2/device_authorization" {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "not_found"})
+			return
+		}
+		writeJSON(w, http.StatusUnauthorized, map[string]string{
+			"error":             "invalid_client",
+			"error_description": "unknown client",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := initiateDeviceAuthorization(context.Background(), srv.URL, "sssoctl", "openid profile email", srv.Client().Do)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	for _, want := range []string{"invalid_client", "unknown client"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error mentioning %q, got: %v", want, err)
+		}
+	}
+}
+
+// Sanity: happy device_authorization returns the parsed RFC 8628 response.
+func TestInitiateDeviceAuthorization_HappyPath(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Errorf("invalid form body: %v", err)
+		}
+		if form.Get("client_id") != "sssoctl" {
+			t.Errorf("expected client_id=sssoctl, got %q", form.Get("client_id"))
+		}
+		if form.Get("scope") != "openid profile email" {
+			t.Errorf("expected scope, got %q", form.Get("scope"))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"device_code":               "dc-1",
+			"user_code":                 "ABCD-EFGH",
+			"verification_uri":          srv.URL + "/oauth2/device/verify",
+			"verification_uri_complete": srv.URL + "/oauth2/device/verify?user_code=ABCD-EFGH",
+			"expires_in":                600,
+			"interval":                  5,
+		})
+	}))
+	defer srv.Close()
+
+	resp, err := initiateDeviceAuthorization(context.Background(), srv.URL+"/", "sssoctl", "openid profile email", srv.Client().Do)
+	if err != nil {
+		t.Fatalf("initiateDeviceAuthorization returned error: %v", err)
+	}
+	if resp.DeviceCode != "dc-1" || resp.UserCode != "ABCD-EFGH" {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	if resp.ExpiresIn != 600 || resp.Interval != 5 {
+		t.Errorf("unexpected expiry/interval: %+v", resp)
+	}
+}
+
+func TestPollForToken_UnexpectedResponseBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "this is not json")
+	}))
+	defer srv.Close()
+
+	_, err := pollForToken(context.Background(), "", "dev-code-1", "sssoctl", time.Millisecond, srv.URL+"/oauth2/token", srv.Client().Do)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "this is not json") {
+		t.Errorf("expected error to include the body excerpt, got: %v", err)
+	}
+}
+
+func TestIDTokenEmail(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"email":"alice@example.com","sub":"u1"}`))
+	got := idTokenEmail("header." + payload + ".sig")
+	if got != "alice@example.com" {
+		t.Errorf("expected alice@example.com, got %q", got)
+	}
+	if idTokenEmail("garbage") != "" {
+		t.Error("expected empty email for malformed id_token")
+	}
+	if idTokenEmail("") != "" {
+		t.Error("expected empty email for empty id_token")
+	}
+}

--- a/openid_config.go
+++ b/openid_config.go
@@ -324,6 +324,8 @@ func NewSSOServer(ctx context.Context, opts SSOServerOptions) (*gin.Engine, erro
 	router.GET("/login/:provider", webauthAPI.SocialLoginHandler)
 	router.GET("/consent", webauthAPI.ConsentPageHandler)
 	router.POST("/consent", webauthAPI.ConsentSubmitHandler)
+	router.GET("/oauth2/device/verify", webauthAPI.DeviceVerificationPageHandler)
+	router.POST("/oauth2/device/verify", webauthAPI.DeviceVerificationSubmitHandler)
 	// ---------- Connect-RPC handlers ----------
 	connectCtx, connectSpan := telemetry.StartSpan(ctx, "shadow-sso", "NewSSOServer.connectrpc")
 	defer connectSpan.End()

--- a/openid_config.go
+++ b/openid_config.go
@@ -326,6 +326,7 @@ func NewSSOServer(ctx context.Context, opts SSOServerOptions) (*gin.Engine, erro
 	router.POST("/consent", webauthAPI.ConsentSubmitHandler)
 	router.GET("/oauth2/device/verify", webauthAPI.DeviceVerificationPageHandler)
 	router.POST("/oauth2/device/verify", webauthAPI.DeviceVerificationSubmitHandler)
+	router.POST("/mfa", webauthAPI.MFASubmitHandler)
 	// ---------- Connect-RPC handlers ----------
 	connectCtx, connectSpan := telemetry.StartSpan(ctx, "shadow-sso", "NewSSOServer.connectrpc")
 	defer connectSpan.End()

--- a/openid_config.go
+++ b/openid_config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pilab-dev/shadow-sso/mongodb"
 	pkgAuth "github.com/pilab-dev/shadow-sso/pkg/auth"
 	"github.com/pilab-dev/shadow-sso/services"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -215,6 +216,13 @@ func NewSSOServer(ctx context.Context, opts SSOServerOptions) (*gin.Engine, erro
 	// persisted AccessTokenLifespan/AccessCodeLifespan instead of hardcoded
 	// values. No-op once the realm_settings collection already holds documents.
 	if err := seedRealmSettingsFromConfig(repoProvider, opts.Config); err != nil {
+		return nil, err
+	}
+
+	// Bootstrap the built-in public "sssoctl" OAuth client used by the ssoctl
+	// CLI device-code login flow. Create-if-missing only: an existing client
+	// with that ID is never modified.
+	if err := ensureBootstrapSSSOCTLClient(ctx, repoProvider.ClientRepository(context.Background()), log.Logger); err != nil {
 		return nil, err
 	}
 
@@ -531,6 +539,37 @@ func seedRealmSettingsFromConfig(repoProvider services.RepositoryProvider, cfg *
 	if _, err := repo.SeedRealmSettingsIfEmpty(ctx, settings); err != nil {
 		return fmt.Errorf("failed to seed realm settings: %w", err)
 	}
+	return nil
+}
+
+// ensureBootstrapSSSOCTLClient idempotently creates the built-in public
+// "sssoctl" OAuth client used by the ssoctl CLI device-code login flow. It is
+// a no-op when the client already exists, so a customized client with that ID
+// is never overwritten.
+func ensureBootstrapSSSOCTLClient(ctx context.Context, clientRepo domain.ClientRepository, log zerolog.Logger) error {
+	if _, err := clientRepo.GetClient(ctx, "sssoctl"); err != nil {
+		if !errors.Is(err, domain.ErrClientNotFound) {
+			return fmt.Errorf("failed to look up sssoctl client: %w", err)
+		}
+		client := &domain.Client{
+			ID:                "sssoctl",
+			Name:              "ssoctl CLI",
+			Type:              domain.ClientTypePublic,
+			IsActive:          true,
+			IsConfidential:    false,
+			TokenEndpointAuth: "none",
+			AllowedGrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
+			AllowedScopes:     []string{"openid", "profile", "email"},
+			RequirePKCE:       false,
+			RequireConsent:    false,
+		}
+		if err := clientRepo.CreateClient(ctx, client); err != nil {
+			return fmt.Errorf("failed to create sssoctl client: %w", err)
+		}
+		log.Info().Str("client_id", "sssoctl").Msg("bootstrapped built-in sssoctl OAuth client")
+		return nil
+	}
+	log.Debug().Str("client_id", "sssoctl").Msg("sssoctl OAuth client already exists, skipping bootstrap")
 	return nil
 }
 

--- a/openid_config.go
+++ b/openid_config.go
@@ -302,19 +302,20 @@ func NewSSOServer(ctx context.Context, opts SSOServerOptions) (*gin.Engine, erro
 	}
 
 	webauthAPI := webauth.New(&webauth.Options{
-		UserRepo:           repoProvider.UserRepository(context.Background()),
-		PasswordHasher:     passwordHasher,
-		FlowStore:          serviceProvider.FlowStore(),
-		UserSessionStore:   serviceProvider.UserSessionStore(),
-		IdPRepository:      repoProvider.IdPRepository(context.Background()),
-		FederationService:  serviceProvider.FederationService(),
-		OAuthService:       serviceProvider.OAuthService(),
-		TokenService:       serviceProvider.TokenService(),
-		ClientService:      serviceProvider.ClientService(),
-		Config:             webauthConfig,
-		SSOCookieSecret:    opts.CookieSigningSecret,
-		AuthFlowRepo:       authFlowRepo,
-		RealmSettingsRepo:  repoProvider.RealmSettingsRepository(context.Background()),
+		UserRepo:          repoProvider.UserRepository(context.Background()),
+		PasswordHasher:    passwordHasher,
+		FlowStore:         serviceProvider.FlowStore(),
+		UserSessionStore:  serviceProvider.UserSessionStore(),
+		IdPRepository:     repoProvider.IdPRepository(context.Background()),
+		FederationService: serviceProvider.FederationService(),
+		OAuthService:      serviceProvider.OAuthService(),
+		TokenService:      serviceProvider.TokenService(),
+		ClientService:     serviceProvider.ClientService(),
+		Config:            webauthConfig,
+		SSOCookieSecret:   opts.CookieSigningSecret,
+		AuthFlowRepo:      authFlowRepo,
+		RealmSettingsRepo: repoProvider.RealmSettingsRepository(context.Background()),
+		DeviceAuthRepo:    repoProvider.DeviceAuthorizationRepository(context.Background()),
 	})
 
 	router.GET("/", webauthAPI.LandingPageHandler)

--- a/openid_config.go
+++ b/openid_config.go
@@ -549,7 +549,7 @@ func seedRealmSettingsFromConfig(repoProvider services.RepositoryProvider, cfg *
 // is never overwritten.
 func ensureBootstrapSSSOCTLClient(ctx context.Context, clientRepo domain.ClientRepository, log zerolog.Logger) error {
 	if _, err := clientRepo.GetClient(ctx, "sssoctl"); err != nil {
-		if !errors.Is(err, domain.ErrClientNotFound) {
+		if !errors.Is(err, domain.ErrClientNotFound) && !errors.Is(err, mongodb.ErrClientNotFound) {
 			return fmt.Errorf("failed to look up sssoctl client: %w", err)
 		}
 		client := &domain.Client{

--- a/openid_config_bootstrap_test.go
+++ b/openid_config_bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pilab-dev/shadow-sso/domain"
 	mock_domain "github.com/pilab-dev/shadow-sso/domain/mocks"
+	"github.com/pilab-dev/shadow-sso/mongodb"
 	"github.com/rs/zerolog"
 	"go.uber.org/mock/gomock"
 )
@@ -92,6 +93,26 @@ func TestEnsureBootstrapSSSOCTLClient_LeavesExistingClientUntouched(t *testing.T
 	}
 	if existing.Type != domain.ClientTypeConfidential || existing.AllowedGrantTypes[0] != "client_credentials" {
 		t.Fatal("existing client was mutated by bootstrap")
+	}
+}
+
+// TestEnsureBootstrapSSSOCTLClient_CreatesOnMongoNotFound verifies the real
+// repository path: mongodb.ClientRepository.GetClient returns its own
+// mongodb.ErrClientNotFound sentinel (mongodb/client_repository.go:20), which
+// is a different error instance from domain.ErrClientNotFound. The bootstrap
+// must accept it as "not found" and create the client.
+func TestEnsureBootstrapSSSOCTLClient_CreatesOnMongoNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mock_domain.NewMockClientRepository(ctrl)
+
+	repo.EXPECT().GetClient(gomock.Any(), "sssoctl").Return(nil, mongodb.ErrClientNotFound)
+	repo.EXPECT().
+		CreateClient(gomock.Any(), gomock.Eq(wantBootstrapClient())).
+		Return(nil).
+		Times(1)
+
+	if err := ensureBootstrapSSSOCTLClient(context.Background(), repo, zerolog.Nop()); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
 	}
 }
 

--- a/openid_config_bootstrap_test.go
+++ b/openid_config_bootstrap_test.go
@@ -1,0 +1,116 @@
+package ssso
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pilab-dev/shadow-sso/domain"
+	mock_domain "github.com/pilab-dev/shadow-sso/domain/mocks"
+	"github.com/rs/zerolog"
+	"go.uber.org/mock/gomock"
+)
+
+// wantBootstrapClient is the exact client ensureBootstrapSSSOCTLClient must
+// create: every field asserted via gomock.Eq deep-equality.
+func wantBootstrapClient() *domain.Client {
+	return &domain.Client{
+		ID:                "sssoctl",
+		Name:              "ssoctl CLI",
+		Type:              domain.ClientTypePublic,
+		IsActive:          true,
+		IsConfidential:    false,
+		TokenEndpointAuth: "none",
+		AllowedGrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
+		AllowedScopes:     []string{"openid", "profile", "email"},
+		RequirePKCE:       false,
+		RequireConsent:    false,
+	}
+}
+
+// TestEnsureBootstrapSSSOCTLClient_CreatesOnFreshRepo verifies that on a fresh
+// repository (GetClient -> ErrClientNotFound) the sssoctl client is created
+// exactly once with all expected fields.
+func TestEnsureBootstrapSSSOCTLClient_CreatesOnFreshRepo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mock_domain.NewMockClientRepository(ctrl)
+
+	repo.EXPECT().GetClient(gomock.Any(), "sssoctl").Return(nil, domain.ErrClientNotFound)
+	repo.EXPECT().
+		CreateClient(gomock.Any(), gomock.Eq(wantBootstrapClient())).
+		Return(nil).
+		Times(1)
+
+	if err := ensureBootstrapSSSOCTLClient(context.Background(), repo, zerolog.Nop()); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+}
+
+// TestEnsureBootstrapSSSOCTLClient_Idempotent verifies that when the client
+// already exists, repeated invocations never call CreateClient.
+func TestEnsureBootstrapSSSOCTLClient_Idempotent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mock_domain.NewMockClientRepository(ctrl)
+
+	repo.EXPECT().
+		GetClient(gomock.Any(), "sssoctl").
+		Return(wantBootstrapClient(), nil).
+		Times(2)
+	repo.EXPECT().CreateClient(gomock.Any(), gomock.Any()).Times(0)
+
+	for i := 0; i < 2; i++ {
+		if err := ensureBootstrapSSSOCTLClient(context.Background(), repo, zerolog.Nop()); err != nil {
+			t.Fatalf("invocation %d: expected nil error, got: %v", i, err)
+		}
+	}
+}
+
+// TestEnsureBootstrapSSSOCTLClient_LeavesExistingClientUntouched verifies that
+// an existing client with custom scopes/grants is neither overwritten nor
+// mutated.
+func TestEnsureBootstrapSSSOCTLClient_LeavesExistingClientUntouched(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mock_domain.NewMockClientRepository(ctrl)
+
+	existing := &domain.Client{
+		ID:                "sssoctl",
+		Name:              "customized cli client",
+		Type:              domain.ClientTypeConfidential,
+		IsActive:          false,
+		IsConfidential:    true,
+		TokenEndpointAuth: "client_secret_basic",
+		AllowedGrantTypes: []string{"client_credentials"},
+		AllowedScopes:     []string{"admin"},
+		RequirePKCE:       true,
+		RequireConsent:    true,
+	}
+	repo.EXPECT().GetClient(gomock.Any(), "sssoctl").Return(existing, nil)
+	repo.EXPECT().CreateClient(gomock.Any(), gomock.Any()).Times(0)
+
+	if err := ensureBootstrapSSSOCTLClient(context.Background(), repo, zerolog.Nop()); err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if existing.Type != domain.ClientTypeConfidential || existing.AllowedGrantTypes[0] != "client_credentials" {
+		t.Fatal("existing client was mutated by bootstrap")
+	}
+}
+
+// TestEnsureBootstrapSSSOCTLClient_PropagatesLookupError verifies that any
+// GetClient error other than ErrClientNotFound is wrapped and returned, and
+// CreateClient is never attempted.
+func TestEnsureBootstrapSSSOCTLClient_PropagatesLookupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	repo := mock_domain.NewMockClientRepository(ctrl)
+
+	lookupErr := errors.New("database down")
+	repo.EXPECT().GetClient(gomock.Any(), "sssoctl").Return(nil, lookupErr)
+	repo.EXPECT().CreateClient(gomock.Any(), gomock.Any()).Times(0)
+
+	err := ensureBootstrapSSSOCTLClient(context.Background(), repo, zerolog.Nop())
+	if err == nil {
+		t.Fatal("expected wrapped error, got nil")
+	}
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("expected wrapped %v, got: %v", lookupErr, err)
+	}
+}

--- a/services/oauth_service.go
+++ b/services/oauth_service.go
@@ -948,7 +948,7 @@ func (s *defaultOAuthService) InitiateDeviceAuthorization(ctx context.Context, c
 		return nil, fmt.Errorf("failed to save device authorization request: %w", err)
 	}
 
-	verificationURI := fmt.Sprintf("%s/device", verificationBaseURI)
+	verificationURI := fmt.Sprintf("%s/oauth2/device/verify", verificationBaseURI)
 	verificationURIComplete := fmt.Sprintf("%s?user_code=%s", verificationURI, userCodeVal)
 
 	log.Ctx(ctx).Info().Str("client_id", clientID).Str("user_code", userCodeVal).Msg("Device authorization flow initiated successfully")

--- a/services/oauth_service_test.go
+++ b/services/oauth_service_test.go
@@ -1310,7 +1310,8 @@ func TestOAuthService_InitiateDeviceAuthorization_Success(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.NotEmpty(t, resp.DeviceCode)
 	assert.NotEmpty(t, resp.UserCode)
-	assert.NotEmpty(t, resp.VerificationURI)
+	assert.Equal(t, "https://device/oauth2/device/verify", resp.VerificationURI)
+	assert.Equal(t, "https://device/oauth2/device/verify?user_code="+resp.UserCode, resp.VerificationURIComplete)
 }
 
 func TestOAuthService_InitiateDeviceAuthorization_InvalidScope(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements the **OAuth 2.0 Device Authorization Grant (RFC 8628)** end-to-end plus the supporting web login flow it depends on:

1. **`ssoctl auth login --device`** — CLI device-flow login: prints verification URI + user code, polls the token endpoint, saves the token to the active context.
2. **Branded device verification page** — `/oauth2/device/verify` renders a branded Approve/Deny page (webauth), replacing the broken/unauthenticated `openidv2_1` implementation (removed atomically).
3. **Flow-less login** — `/login` with a validated, HMAC-signed `return_to` cookie for direct device-verification access without an OIDC client context.
4. **MFA completion redirect fallback** — `POST /mfa` handler: real TOTP validation; completes synthetic (flow-less) logins by redirecting to `return_to` (or `/`) and real OIDC flows to `/oauth2/authorize?flow_id=...`.
5. **Infrastructure fixes uncovered at real boot**: idempotent `sssoctl` client bootstrap (handles the mongodb `ErrClientNotFound` sentinel) and fail-closed wiring of the cookie signing secret for `sso_session` cookies.

## Commits (9)

| Commit | Change |
|---|---|
| `e3f63f3a` | feat(client): bootstrap built-in sssoctl OAuth client on server start |
| `eef7d58e` | fix(oauth): point device verification URI at /oauth2/device/verify |
| `38f74e5d` | refactor(webauth): add device authorization repository dependency |
| `b5762e9f` | fix(client): handle mongodb ErrClientNotFound during sssoctl bootstrap |
| `375f4e26` | fix(config): wire and enforce cookie signing secret for sso_session cookies |
| `05aaca43` | feat(webauth): branded device verification page with approve/deny |
| `e00496ab` | feat(webauth): flow-less login with signed return_to support |
| `90685920` | feat(ssoctl): add device-flow login via auth login --device |
| `1419a217` | fix(webauth): redirect flow-less MFA completion to return_to |

## Verification

Final verification wave (F1–F4) all APPROVE:
- **F1 Plan compliance** — commit messages match the plan word-for-word; per-todo file scopes honored; hunk-level split of shared `openid_config.go` verified.
- **F2 Code quality** — CSRF-first POSTs, HMAC-signed session cookies, open-redirect guards, real TOTP validation; `go vet` + `go build` clean.
- **F3 Real manual QA** — live end-to-end: `ssoctl auth login --device` → login → verify page → approve → token saved to context; deny path returns `access_denied`; `verification_uri` exact; bootstrap idempotent.
- **F4 Scope fidelity** — 9/9 commits exact; no pre-existing dirty files (domain/mongodb/graphql/dtsclient/services) committed.

## Notes

- Single-realm, single `sssoctl` public client (`device_code` + `refresh_token` grants), bootstrap is idempotent (no-op on restart, never overwrites a customized client).
- Pre-existing dirty worktree changes (graphql/mongodb/federation) were intentionally left uncommitted and are **not** part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth device authorization login support to the command-line tool, including browser verification, polling, and token storage.
  * Added a device activation page with approve and deny actions.
  * Added MFA submission support with validation and secure redirects.
  * Added flow-less login redirects with protected return destinations.
* **Security**
  * Added signed return destinations, CSRF protection, and required cookie-signing configuration.
* **Bug Fixes**
  * Updated device verification links to use the correct activation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->